### PR TITLE
Add `-n` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Commands:
   github-nippou list            # Displays today's GitHub events formatted for Nippou
 
 Options:
-  a, [--all], [--no-all]  # Displays all events that can retrieve from GitHub
+  a, [--all], [--no-all]  # Also displays GitHub events before today
+  n, [--num=N]            # GitHub event numbers that retrieve from GitHub
+                          # Default: 50
 ```
 
 You can omit the sub command `list`.

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -16,6 +16,7 @@ module Github
 
       default_task :list
       class_option :all, type: :boolean, aliases: :a, desc: 'Displays all events that can retrieve from GitHub'
+      class_option :num, type: :numeric, default: 50, aliases: :n, desc: 'GitHub event numbers that retrieve from GitHub'
 
       desc 'list', "Displays today's GitHub events formatted for Nippou"
       def list
@@ -32,7 +33,7 @@ module Github
         result = {}
         now = Time.now
 
-        client.user_events(user).each do |event|
+        client.user_events(user, per_page: options[:num]).each do |event|
           break if skip?(event, now)
 
           case event.type

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -15,7 +15,7 @@ module Github
       using StringExMarkdown
 
       default_task :list
-      class_option :all, type: :boolean, aliases: :a, desc: 'Displays all events that can retrieve from GitHub'
+      class_option :all, type: :boolean, aliases: :a, desc: 'Also displays GitHub events before today'
       class_option :num, type: :numeric, default: 50, aliases: :n, desc: 'GitHub event numbers that retrieve from GitHub'
 
       desc 'list', "Displays today's GitHub events formatted for Nippou"


### PR DESCRIPTION
> https://developer.github.com/v3/activity/events/
>
> Events support pagination, however the per_page option is unsupported. The fixed page size is 30 items. Fetching up to ten pages is supported, for a total of 300 events.

デフォルト 30 だったから、取りこぼしが起きていたんだ。。勘違いしてた。
#19 を作ったのも忘れてた。

というわけで、`-n` オプション作った。デフォルトは 50。
100 だと 20 秒とかかかるのでこの辺で妥協。