### PR TITLE
Add `--until-date (-u)` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,22 @@ Commands:
   github-nippou list            # Displays today's GitHub events formatted for Nippou
 
 Options:
-  a, [--all], [--no-all]  # Also displays GitHub events before today
-  n, [--num=N]            # GitHub event numbers that retrieve from GitHub
-                          # Default: 50
+  s, [--since-date=SINCE_DATE]  # Retrieves GitHub user_events since the date
+                                # Default: 20160326
+  u, [--until-date=UNTIL_DATE]  # Retrieves GitHub user_events until the date
+                                # Default: 20160326
+```
+
+You can get your GitHub Nippou on today.
+
+```
+$ github-nippou list
+* [Bundle Update on 2016-03-24 - masutaka/awesome-github-feed](https://github.com/masutaka/awesome-github-feed/pull/38) by deppbot **merged!**
+* [Fix performance - masutaka/github-nippou](https://github.com/masutaka/github-nippou/pull/44) by masutaka **merged!**
+* [Bundle Update on 2016-03-24 - masutaka/masutaka-29hours](https://github.com/masutaka/masutaka-29hours/pull/19) by deppbot **merged!**
+* [Bundle Update on 2016-03-24 - masutaka/masutaka-metrics](https://github.com/masutaka/masutaka-metrics/pull/34) by deppbot **merged!**
+* [bundle update at 2016-03-25 18:32:43 JST - masutaka/masutaka.net](https://github.com/masutaka/masutaka.net/pull/52) by masutaka **merged!**
+* [bundle update at 2016-03-25 10:02:02 UTC - masutaka/server-masutaka.net](https://github.com/masutaka/server-masutaka.net/pull/211) by masutaka **merged!**
 ```
 
 You can omit the sub command `list`.

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -17,6 +17,9 @@ module Github
       class_option :since_date, type: :string,
                    default: Time.now.strftime('%Y%m%d'),
                    aliases: :s, desc: 'Retrieves GitHub user_events since the date'
+      class_option :until_date, type: :string,
+                   default: Time.now.strftime('%Y%m%d'),
+                   aliases: :u, desc: 'Retrieves GitHub user_events until the date'
 
       desc 'list', "Displays today's GitHub events formatted for Nippou"
       def list
@@ -52,7 +55,7 @@ module Github
 
       def user_events
         @user_events ||= UserEvents.new(
-          client, user, options[:since_date]
+          client, user, options[:since_date], options[:until_date]
         ).retrieve
       end
 

--- a/lib/github/nippou/user_events.rb
+++ b/lib/github/nippou/user_events.rb
@@ -4,17 +4,18 @@ require 'octokit'
 module Github
   module Nippou
     class UserEvents
-      def initialize(client, user, since_date)
+      def initialize(client, user, since_date, until_date)
         @client = client
         @user = user
-        @range = Time.parse(since_date)..Time.now.end_of_day
+        @since_date = Time.parse(since_date).beginning_of_day
+        @until_date = Time.parse(until_date).end_of_day
       end
 
       def retrieve
         user_events = @client.user_events(@user, per_page: 100)
         last_response = @client.last_response
 
-        while last_response.rels[:next] && in_range?(user_events.last)
+        while last_response.rels[:next] && continue?(user_events.last)
           last_response = last_response.rels[:next].get
           user_events.concat(last_response.data)
         end
@@ -24,8 +25,12 @@ module Github
 
       private
 
+      def continue?(user_event)
+        user_event.created_at.getlocal >= @since_date
+      end
+
       def in_range?(user_event)
-        @range.include?(user_event.created_at.getlocal)
+        (@since_date..@until_date).include?(user_event.created_at.getlocal)
       end
     end
   end

--- a/lib/github/nippou/user_events.rb
+++ b/lib/github/nippou/user_events.rb
@@ -15,7 +15,7 @@ module Github
         user_events = @client.user_events(@user, per_page: 100)
         last_response = @client.last_response
 
-        while last_response.rels[:next] && continue?(user_events.last)
+        while continue?(last_response, user_events)
           last_response = last_response.rels[:next].get
           user_events.concat(last_response.data)
         end
@@ -25,8 +25,9 @@ module Github
 
       private
 
-      def continue?(user_event)
-        user_event.created_at.getlocal >= @since_date
+      def continue?(last_response, user_events)
+        last_response.rels[:next] &&
+          user_events.last.created_at.getlocal >= @since_date
       end
 
       def in_range?(user_event)


### PR DESCRIPTION
You can execute the below commands.

    $ github-nippou -s 20160318 -u 20160318
    $ github-nippou -s 20160318 -u 20160319
    $ github-nippou -s 20160325

The below is invalid. Because the default of `-s` is TODAY.

    $ github-nippou -u 20160325

