### PR TITLE
Improve performance using thread

### DIFF
--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -17,7 +17,6 @@ module Github
       desc 'list', "Displays today's GitHub events formatted for Nippou"
       def list
         lines = []
-        thread_num = 5
         threads = []
         mutex1 = Mutex::new
         mutex2 = Mutex::new
@@ -111,6 +110,18 @@ https://github.com/settings/tokens/new
 MESSAGE
             exit!
           end
+      end
+
+      def thread_num
+        @thread_num ||=
+          case
+          when ENV['GITHUB_NIPPOU_THREAD_NUM']
+            ENV['GITHUB_NIPPOU_THREAD_NUM']
+          when !`git config github-nippou.thread-num`.chomp.empty?
+            `git config github-nippou.thread-num`.chomp
+          else
+            5
+          end.to_i
       end
     end
   end

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -29,14 +29,9 @@ module Github
             end
           end
         end
-
         threads.each(&:join)
 
-        lines.sort do |a, b|
-          a.html_url_as_nippou <=> b.html_url_as_nippou
-        end.each do |line|
-          puts line
-        end
+        puts sort(lines)
       end
 
       desc 'version', 'Displays version'
@@ -64,7 +59,7 @@ module Github
           line << ' **closed!**'
         end
 
-        line + "\n"
+        line
       end
 
       def issue(user_event)
@@ -72,6 +67,12 @@ module Github
           client.issue(user_event.repo.name, user_event.payload.issue.number)
         else
           client.pull_request(user_event.repo.name, user_event.payload.pull_request.number)
+        end
+      end
+
+      def sort(lines)
+        lines.sort do |a, b|
+          a.html_url_as_nippou <=> b.html_url_as_nippou
         end
       end
 

--- a/lib/github/nippou/concerns/string_markdown.rb
+++ b/lib/github/nippou/concerns/string_markdown.rb
@@ -3,5 +3,10 @@ module StringMarkdown
     def markdown_escape
       self.gsub(/([`<>])/, '\\\\\1')
     end
+
+    def html_url_as_nippou
+      self =~ /^\* \[.+\]\((.+)\)/
+      $1
+    end
   end
 end

--- a/lib/github/nippou/user_events.rb
+++ b/lib/github/nippou/user_events.rb
@@ -15,7 +15,7 @@ module Github
       end
 
       def collect
-        uniq(sort(filter(retrieve)))
+        uniq(filter(retrieve))
       end
 
       private
@@ -44,12 +44,6 @@ module Github
       def filter(user_events)
         user_events.select do |user_event|
           user_event.issue? || user_event.pull_request?
-        end
-      end
-
-      def sort(user_events)
-        user_events.sort do |a, b|
-          a.html_url <=> b.html_url
         end
       end
 


### PR DESCRIPTION
### Before

**19.019 sec** in the case of single thread

```
$ time bundle exec ruby bin/github-nippou -s 20160327
(17 items)
bundle exec ruby bin/github-nippou -s 20160327  1.52s user 0.26s system 9% cpu 19.019 total
```

### After

**7.006 sec** in the case of 5 threads (default)

```
$ time bundle exec ruby bin/github-nippou -s 20160327
(17 items)
bundle exec ruby bin/github-nippou -s 20160327  1.68s user 0.28s system 28% cpu 7.006 total
```

**5.525 sec** in the case of 10 threads

```
$ $ time GITHUB_NIPPOU_THREAD_NUM=10 bundle exec ruby bin/github-nippou -s 20160327
(17 items)
GITHUB_NIPPOU_THREAD_NUM=10 bundle exec ruby bin/github-nippou -s 20160327  1.55s user 0.27s system 32% cpu 5.525 total
```
