### PR TITLE
Enable to inject settings_gist_id instead of the settings

### DIFF
--- a/spec/fixtures/settings-invalid.yml
+++ b/spec/fixtures/settings-invalid.yml
@@ -1,0 +1,7 @@
+format:
+  **!!invalid!!**
+  line: '* [%{title}](%{url}) by %{user} %{status}'
+dictionary:
+  status:
+    merged: '**merged!**'
+    closed: '**closed!**'

--- a/spec/fixtures/settings-valid.yml
+++ b/spec/fixtures/settings-valid.yml
@@ -1,0 +1,7 @@
+format:
+  subject: '### %{subject}'
+  line: '* [%{title}](%{url}) by %{user} %{status}'
+dictionary:
+  status:
+    merged: '**merged!**'
+    closed: '**closed!**'

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -3,17 +3,13 @@ describe Github::Nippou::Settings do
   let(:settings) { described_class.new(client: client) }
 
   describe '#format' do
-    context 'given valid settings' do
-      let(:settings_format) do
-        {
-          format: {
-            subject: '### %{subject}',
-            line: '* [%{title}](%{url}) by %{user} %{status}',
-          },
-        }
-      end
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
 
-      before { ENV['GITHUB_NIPPOU_SETTINGS'] = settings_format.to_yaml }
+    context 'given valid settings' do
+      let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
       it 'is valid `subject`' do
         expect(settings.format.subject).to eq '### %{subject}'
@@ -25,15 +21,7 @@ describe Github::Nippou::Settings do
     end
 
     context 'given invalid settings' do
-      let(:settings_format_yaml) do
-        <<~INVALID_YAML
-        format:
-          **!!invalid!!**
-          line: '* [%{title}](%{url}) by %{user} %{status}'
-        INVALID_YAML
-      end
-
-      before { ENV['GITHUB_NIPPOU_SETTINGS'] = settings_format_yaml }
+      let(:settings_yaml) { load_fixture('settings-invalid.yml') }
 
       it 'outputs YAML syntax error message' do
         expect { settings.format }.to raise_error Psych::SyntaxError
@@ -42,19 +30,13 @@ describe Github::Nippou::Settings do
   end
 
   describe '#dictionary' do
-    context 'given valid settings' do
-      let(:settings_dictionary) do
-        {
-          dictionary: {
-            status: {
-              merged: '**merged!**',
-              closed: '**closed!**',
-            },
-          },
-        }
-      end
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
 
-      before { ENV['GITHUB_NIPPOU_SETTINGS'] = settings_dictionary.to_yaml }
+    context 'given valid settings' do
+      let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
       it 'is valid `status.merged`' do
         expect(settings.dictionary.status.merged).to eq '**merged!**'
@@ -64,23 +46,24 @@ describe Github::Nippou::Settings do
         expect(settings.dictionary.status.closed).to eq '**closed!**'
       end
     end
+
+    context 'given invalid settings' do
+      let(:settings_yaml) { load_fixture('settings-invalid.yml') }
+
+      it 'outputs YAML syntax error message' do
+        expect { settings.dictionary }.to raise_error Psych::SyntaxError
+      end
+    end
   end
 
   describe '#yaml' do
-    context 'given valid settings' do
-      let(:settings_yaml) do
-        <<~VALID_YAML
-        format:
-          subject: "### %{subject}"
-          line: "* [%{title}](%{url}) by %{user} %{status}"
-        dictionary:
-          status:
-            merged: "**merged!**"
-            closed: "**closed!**"
-        VALID_YAML
-      end
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
 
-      before { ENV['GITHUB_NIPPOU_SETTINGS'] = settings_yaml }
+    context 'given valid settings' do
+      let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
       it 'is valid yaml' do
         expect(settings.yaml).to eq <<~VALID_YAML
@@ -93,6 +76,14 @@ describe Github::Nippou::Settings do
               :merged: "**merged!**"
               :closed: "**closed!**"
         VALID_YAML
+      end
+    end
+
+    context 'given invalid settings' do
+      let(:settings_yaml) { load_fixture('settings-invalid.yml') }
+
+      it 'outputs YAML syntax error message' do
+        expect { settings.yaml }.to raise_error Psych::SyntaxError
       end
     end
   end

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -2,12 +2,12 @@ describe Github::Nippou::Settings do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
   let(:settings) { described_class.new(client: client) }
 
-  describe '#format' do
-    before do
-      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
-      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
-    end
+  before do
+    ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+    allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+  end
 
+  describe '#format' do
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
@@ -30,11 +30,6 @@ describe Github::Nippou::Settings do
   end
 
   describe '#dictionary' do
-    before do
-      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
-      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
-    end
-
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
@@ -57,11 +52,6 @@ describe Github::Nippou::Settings do
   end
 
   describe '#yaml' do
-    before do
-      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
-      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
-    end
-
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,12 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -95,12 +101,6 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ end
 RSpec.configure do |config|
   config.include LoadFixtureHelper
 
+  config.before(:all) { silence_stdout }
+  config.after(:all){ enable_stdout }
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -105,4 +108,16 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+end
+
+# Redirects stdout to /dev/null.
+def silence_stdout
+  @orig_stdout = $stdout
+  $stdout = File.new('/dev/null', 'w')
+end
+
+# Replace stdout so anything else is output correctly.
+def enable_stdout
+  $stdout = @orig_stdout
+  @orig_stdout = nil
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,14 @@
 
 require 'github/nippou'
 
+Dir[File.expand_path('support/**/*.rb', __dir__)].each do |f|
+  require f
+end
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include LoadFixtureHelper
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/load_fixture.rb
+++ b/spec/support/load_fixture.rb
@@ -1,0 +1,5 @@
+module LoadFixtureHelper
+  def load_fixture(name)
+    File.read(File.expand_path("../fixtures/#{name}", __dir__))
+  end
+end


### PR DESCRIPTION
* IN: `$GITHUB_NIPPOU_SETTINGS_GIST_ID`
* OUT: `github-nippou.settings` in ~/.gitconfig and `$GITHUB_NIPPOU_SETTINGS` 

https://github.com/masutaka/github-nippou/pull/58#discussion_r130233974 の辺りで話した件。

Dockerize も見据えると、Gist ID を環境変数で Inject 出来たほうが都合が良い（~/.gitconfig の `github-nippou.settings-gist-id` はすでに Inject 出来ていた）。