### PR TITLE
Add y/n prompt to sub command `init`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     github-nippou (3.0.0.beta1)
       activesupport
+      highline
       octokit
       parallel
       thor
@@ -10,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.2)
+    activesupport (5.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -21,6 +22,7 @@ GEM
     diff-lcs (1.3)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
+    highline (1.7.8)
     i18n (0.8.6)
     minitest (5.10.3)
     multipart-post (2.0.0)

--- a/github-nippou.gemspec
+++ b/github-nippou.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'highline'
   spec.add_dependency 'octokit'
   spec.add_dependency 'parallel'
   spec.add_dependency 'thor'

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -1,3 +1,4 @@
+require 'highline/import'
 require 'parallel'
 require 'thor'
 require 'yaml'
@@ -50,6 +51,13 @@ module Github
             It already have gist id that github-nippou.settings-gist-id on your .gitconfig.
           MESSAGE
           exit
+        end
+
+        puts 'This command will create a gist and update your `~/.gitconfig`.'
+
+        unless HighLine.agree('Are you sure? [y/n] ')
+          puts 'Canceled.'
+          abort
         end
 
         gist = settings.create_gist

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -36,31 +36,31 @@ module Github
           puts <<~MESSAGE
             ** Gist scope required.
 
-            You need personal access token which has gist scope.
-            Please add gist scope on your personal access token if you use this command.
+            You need personal access token which has `gist` scope.
+            Please add `gist` scope to your personal access token, visit
+            https://github.com/settings/tokens
           MESSAGE
           exit!
         end
-        unless `git config github-nippou.settings-gist-id`.chomp.empty?
+
+        if settings.gist_id.present?
           puts <<~MESSAGE
             ** Already initialized.
 
             It already have gist id that github-nippou.settings-gist-id on your .gitconfig.
           MESSAGE
-          exit!
+          exit
         end
 
-        result = client.create_gist(
-          description: 'github-nippou settings',
-          public: true,
-          files: { 'settings.yml' => { content: settings.yaml }}
-        ).to_h
-        `git config --global github-nippou.settings-gist-id #{result[:id]}`
+        gist = settings.create_gist
+        `git config --global github-nippou.settings-gist-id #{gist[:id]}`
 
         puts <<~MESSAGE
-          The github-nippou settings was created on following url: #{result[:html_url]}
-          And the gist id was set your .gitconfig
-          You can check the gist id with following command
+          The github-nippou settings was created on #{gist[:html_url]}
+
+          And the gist_id was appended to your .gitconfig. You can
+          check the gist_id with following command.
+
               $ git config --global github-nippou.settings-gist-id
         MESSAGE
       end
@@ -114,7 +114,7 @@ module Github
               Please set github-nippou.token to your .gitconfig.
                   $ git config --global github-nippou.token [Your GitHub access token]
 
-              To get new token with `repo` scope, visit
+              To get new token with `repo` and `gist` scope, visit
               https://github.com/settings/tokens/new
             MESSAGE
             exit!

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -48,7 +48,7 @@ module Github
           puts <<~MESSAGE
             ** Already initialized.
 
-            It already have gist id that github-nippou.settings-gist-id on your .gitconfig.
+            Your `~/.gitconfig` already has gist_id as `github-nippou.settings-gist-id`.
           MESSAGE
           exit
         end
@@ -66,7 +66,7 @@ module Github
         puts <<~MESSAGE
           The github-nippou settings was created on #{gist[:html_url]}
 
-          And the gist_id was appended to your .gitconfig. You can
+          And the gist_id was appended to your `~/.gitconfig`. You can
           check the gist_id with following command.
 
               $ git config --global github-nippou.settings-gist-id
@@ -101,7 +101,7 @@ module Github
             puts <<~MESSAGE
               ** User required.
 
-              Please set github-nippou.user to your .gitconfig.
+              Please set github-nippou.user to your `~/.gitconfig`.
                   $ git config --global github-nippou.user [Your GitHub account]
             MESSAGE
             exit!
@@ -119,7 +119,7 @@ module Github
             puts <<~MESSAGE
               ** Authorization required.
 
-              Please set github-nippou.token to your .gitconfig.
+              Please set github-nippou.token to your `~/.gitconfig`.
                   $ git config --global github-nippou.token [Your GitHub access token]
 
               To get new token with `repo` and `gist` scope, visit

--- a/lib/github/nippou/settings.rb
+++ b/lib/github/nippou/settings.rb
@@ -29,7 +29,7 @@ module Github
         client.create_gist(
           description: 'github-nippou settings',
           public: true,
-          files: { 'settings.yml' => { content: default_yaml }}
+          files: { 'settings.yml' => { content: default_settings.to_yaml }}
         )
       end
 
@@ -51,11 +51,11 @@ module Github
 
       attr_reader :client
 
-      # Getting default settings.yml
+      # Getting default settings.yml as Hash
       #
-      # return [String]
-      def default_yaml
-        @default_yaml ||=
+      # return [Hash]
+      def default_settings
+        @default_settings ||=
           YAML.load_file(
             File.expand_path('../../../config/settings.yml', __dir__)
           )
@@ -72,7 +72,7 @@ module Github
               yaml_data = gist[:files][:'settings.yml'][:content]
               YAML.load(yaml_data).deep_symbolize_keys
             else
-              default_yaml.deep_symbolize_keys
+              default_settings.deep_symbolize_keys
             end
           rescue Psych::SyntaxError
             puts <<~MESSAGE

--- a/lib/github/nippou/settings.rb
+++ b/lib/github/nippou/settings.rb
@@ -8,6 +8,31 @@ module Github
         @client = client
       end
 
+      # Getting gist id which has settings.yml
+      #
+      # @return [String] gist id
+      def gist_id
+        @gist_id ||=
+          begin
+            ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] ||
+              begin
+                git_config = `git config github-nippou.settings-gist-id`.chomp
+                git_config.present? ? git_config : nil
+              end
+          end
+      end
+
+      # Create gist with config/settings.yml
+      #
+      # @return [Sawyer::Resource]
+      def create_gist
+        client.create_gist(
+          description: 'github-nippou settings',
+          public: true,
+          files: { 'settings.yml' => { content: yaml }}
+        )
+      end
+
       # Getting format settings
       #
       # @return [OpenStruct]
@@ -55,20 +80,6 @@ module Github
               #{yaml_data}
             MESSAGE
             raise $!
-          end
-      end
-
-      # Getting gist id which has settings.yml
-      #
-      # @return [String] gist id
-      def gist_id
-        @gist_id ||=
-          begin
-            ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] ||
-              begin
-                git_config = `git config github-nippou.settings-gist-id`.chomp
-                git_config.present? ? git_config : nil
-              end
           end
       end
 

--- a/lib/github/nippou/settings.rb
+++ b/lib/github/nippou/settings.rb
@@ -29,7 +29,7 @@ module Github
         client.create_gist(
           description: 'github-nippou settings',
           public: true,
-          files: { 'settings.yml' => { content: yaml }}
+          files: { 'settings.yml' => { content: default_yaml }}
         )
       end
 
@@ -47,16 +47,19 @@ module Github
         open_struct(data[:dictionary])
       end
 
-      # Getting settings as YAML format
-      #
-      # return [String]
-      def yaml
-        data.to_yaml
-      end
-
       private
 
       attr_reader :client
+
+      # Getting default settings.yml
+      #
+      # return [String]
+      def default_yaml
+        @default_yaml ||=
+          YAML.load_file(
+            File.expand_path('../../../config/settings.yml', __dir__)
+          )
+      end
 
       # Getting settings data as Hash
       #
@@ -69,8 +72,7 @@ module Github
               yaml_data = gist[:files][:'settings.yml'][:content]
               YAML.load(yaml_data).deep_symbolize_keys
             else
-              default_yml = File.expand_path('../../../config/settings.yml', __dir__)
-              YAML.load_file(default_yml).deep_symbolize_keys
+              default_yaml.deep_symbolize_keys
             end
           rescue Psych::SyntaxError
             puts <<~MESSAGE

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -71,36 +71,4 @@ describe Github::Nippou::Settings do
       end
     end
   end
-
-  describe '#yaml' do
-    before do
-      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
-      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
-    end
-
-    context 'given valid settings' do
-      let(:settings_yaml) { load_fixture('settings-valid.yml') }
-
-      it 'is valid yaml' do
-        expect(settings.yaml).to eq <<~VALID_YAML
-          ---
-          :format:
-            :subject: "### %{subject}"
-            :line: "* [%{title}](%{url}) by %{user} %{status}"
-          :dictionary:
-            :status:
-              :merged: "**merged!**"
-              :closed: "**closed!**"
-        VALID_YAML
-      end
-    end
-
-    context 'given invalid settings' do
-      let(:settings_yaml) { load_fixture('settings-invalid.yml') }
-
-      it 'outputs YAML syntax error message' do
-        expect { settings.yaml }.to raise_error Psych::SyntaxError
-      end
-    end
-  end
 end

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -2,12 +2,28 @@ describe Github::Nippou::Settings do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
   let(:settings) { described_class.new(client: client) }
 
-  before do
-    ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
-    allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+  describe '#gist_id' do
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '0123456789'
+    end
+
+    it 'is valid' do
+      expect(settings.gist_id).to eq '0123456789'
+    end
+  end
+
+  describe '#create_gist' do
+    it 'responds to #create_gist' do
+      expect(client).to respond_to :create_gist
+    end
   end
 
   describe '#format' do
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
+
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
@@ -30,6 +46,11 @@ describe Github::Nippou::Settings do
   end
 
   describe '#dictionary' do
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
+
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 
@@ -52,6 +73,11 @@ describe Github::Nippou::Settings do
   end
 
   describe '#yaml' do
+    before do
+      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '12345'
+      allow(client).to receive(:gist).and_return( files: { 'settings.yml': { content: settings_yaml } } )
+    end
+
     context 'given valid settings' do
       let(:settings_yaml) { load_fixture('settings-valid.yml') }
 

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -3,9 +3,7 @@ describe Github::Nippou::Settings do
   let(:settings) { described_class.new(client: client) }
 
   describe '#gist_id' do
-    before do
-      ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '0123456789'
-    end
+    before { ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '0123456789' }
 
     it 'is valid' do
       expect(settings.gist_id).to eq '0123456789'


### PR DESCRIPTION
https://github.com/masutaka/github-nippou/pull/58#discussion_r130234247 で話した件。

`$ github-nippou init` では有無を言わさず

1. Gist を作成
2. ~/.gitconfig への書き込み

が行われるため、確認のプロンプトを出すようにした。

## y

```
$ bundle exec bin/github-nippou init
This command will create a gist and update your `~/.gitconfig`.
Are you sure? [y/n] y
The github-nippou settings was created on https://gist.github.com/1234abcd

And the gist_id was appended to your `~/.gitconfig`. You can
check the gist_id with following command.

    $ git config --global github-nippou.settings-gist-id
```

## n

```
$ bundle exec bin/github-nippou init
This command will create a gist and update your `~/.gitconfig`.
Are you sure? [y/n] n
Canceled.
```
