### PR TITLE
Merge Setup in README.md to sub command `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [gem-link]: http://badge.fury.io/rb/github-nippou
 [dockerhub]: https://hub.docker.com/r/masutaka/github-nippou/
 
-Displays today's your GitHub action.
+Print today's your GitHub action.
 
 This is a helpful tool when you write a daily report in reference to
 GitHub. Nippou is a japanese word which means a daily report.
@@ -35,8 +35,13 @@ Or install it yourself as:
 
 ## Setup
 
-    $ git config --global github-nippou.user [Your GitHub account]
-    $ git config --global github-nippou.token [Your GitHub access token]
+    $ github-nippou init
+
+The initialization will be update your `~/.gitconfig`.
+
+1. Add `github-nippou.user`
+2. Add `github-nippou.token`
+3. Create Gist, and add `github-nippou.settings-gist-id` for customizing output format (optional)
 
 ## Usage
 
@@ -44,16 +49,16 @@ Or install it yourself as:
 $ github-nippou help
 Commands:
   github-nippou help [COMMAND]  # Describe available commands or one specific command
-  github-nippou init            # Synchronize github-nippou settings on your gist
-  github-nippou list            # Displays today's GitHub events formatted for Nippou (Default)
+  github-nippou init            # Initialize github-nippou settings
+  github-nippou list            # Print today's your GitHub action (Default)
   github-nippou open-settings   # Open settings url with web browser
-  github-nippou version         # Displays version
+  github-nippou version         # Print version
 
 Options:
   s, [--since-date=SINCE_DATE]  # Retrieves GitHub user_events since the date
-                                # Default: 20170807
+                                # Default: 20170819
   u, [--until-date=UNTIL_DATE]  # Retrieves GitHub user_events until the date
-                                # Default: 20170807
+                                # Default: 20170819
   d, [--debug], [--no-debug]    # Debug mode
 
 ```
@@ -65,32 +70,11 @@ $ github-nippou
 
 ### masutaka/github-nippou
 
-* [v3.0.0](https://github.com/masutaka/github-nippou/issues/59) by masutaka
-* [Enable to inject settings_gist_id instead of the settings](https://github.com/masutaka/github-nippou/pull/63) by masutaka **merged!**
-* [Add y/n prompt to sub command \`init\`](https://github.com/masutaka/github-nippou/pull/64) by masutaka **merged!**
-* [Add sub command \`open-settings\`](https://github.com/masutaka/github-nippou/pull/65) by masutaka **merged!**
-* [Dockerize](https://github.com/masutaka/github-nippou/pull/66) by masutaka **merged!**
-```
-
-## Customize output format
-
-```
-$ github-nippou init
-This command will create a gist and update your `~/.gitconfig`.
-Are you sure? [y/n] y
-The github-nippou settings was created on https://gist.github.com/ecfa35cb546d8462277d133a91b13be9
-
-And the gist_id was appended to your `~/.gitconfig`. You can
-check the gist_id with following command.
-
-    $ git config --global github-nippou.settings-gist-id
-```
-
-Open the Gist URL with your web browser.
-
-```
-$ github-nippou open-settings
-Open https://gist.github.com/ecfa35cb546d8462277d133a91b13be9
+* [v3.0.0](https://github.com/masutaka/github-nippou/issues/59) by @[masutaka](https://github.com/masutaka)
+* [Enable to inject settings_gist_id instead of the settings](https://github.com/masutaka/github-nippou/pull/63) by @[masutaka](https://github.com/masutaka) **merged!**
+* [Add y/n prompt to sub command \`init\`](https://github.com/masutaka/github-nippou/pull/64) by @[masutaka](https://github.com/masutaka) **merged!**
+* [Add sub command \`open-settings\`](https://github.com/masutaka/github-nippou/pull/65) by @[masutaka](https://github.com/masutaka) **merged!**
+* [Dockerize](https://github.com/masutaka/github-nippou/pull/66) by @[masutaka](https://github.com/masutaka) **merged!**
 ```
 
 ## Docker

--- a/lib/github/nippou.rb
+++ b/lib/github/nippou.rb
@@ -3,6 +3,7 @@ require 'github/nippou/concerns/string_markdown'
 
 require 'github/nippou/commands'
 require 'github/nippou/format'
+require 'github/nippou/init'
 require 'github/nippou/settings'
 require 'github/nippou/user_events'
 require 'github/nippou/version'

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -1,4 +1,3 @@
-require 'highline/import'
 require 'launchy'
 require 'parallel'
 require 'thor'
@@ -34,44 +33,7 @@ module Github
 
       desc 'init', 'Synchronize github-nippou settings on your gist'
       def init
-        unless client.scopes.include? 'gist'
-          puts <<~MESSAGE
-            ** Gist scope required.
-
-            You need personal access token which has `gist` scope.
-            Please add `gist` scope to your personal access token, visit
-            https://github.com/settings/tokens
-          MESSAGE
-          exit!
-        end
-
-        if settings.gist_id.present?
-          puts <<~MESSAGE
-            ** Already initialized.
-
-            Your `~/.gitconfig` already has gist_id as `github-nippou.settings-gist-id`.
-          MESSAGE
-          exit
-        end
-
-        puts 'This command will create a gist and update your `~/.gitconfig`.'
-
-        unless HighLine.agree('Are you sure? [y/n] ')
-          puts 'Canceled.'
-          abort
-        end
-
-        gist = settings.create_gist
-        `git config --global github-nippou.settings-gist-id #{gist.id}`
-
-        puts <<~MESSAGE
-          The github-nippou settings was created on #{gist.html_url}
-
-          And the gist_id was appended to your `~/.gitconfig`. You can
-          check the gist_id with following command.
-
-              $ git config --global github-nippou.settings-gist-id
-        MESSAGE
+        Init.new(client: client, settings: settings).run
       end
 
       desc 'open-settings', 'Open settings url with web browser'

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -19,7 +19,7 @@ module Github
       def list
         lines = []
         mutex = Mutex.new
-        format = Format.new(client, settings.thread_num, settings, debug)
+        format = Format.new(client, settings, debug)
 
         Parallel.each_with_index(user_events, in_threads: settings.thread_num) do |user_event, i|
           # Contain GitHub access.

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -19,7 +19,7 @@ module Github
       def list
         lines = []
         mutex = Mutex.new
-        format = Format.new(client, settings, debug)
+        format = Format.new(settings.client, settings, debug)
 
         Parallel.each_with_index(user_events, in_threads: settings.thread_num) do |user_event, i|
           # Contain GitHub access.
@@ -33,7 +33,7 @@ module Github
 
       desc 'init', 'Synchronize github-nippou settings on your gist'
       def init
-        Init.new(client: client, settings: settings).run
+        Init.new(client: settings.client, settings: settings).run
       end
 
       desc 'open-settings', 'Open settings url with web browser'
@@ -51,12 +51,8 @@ module Github
 
       def user_events
         @user_events ||= UserEvents.new(
-          client, settings.user, options[:since_date], options[:until_date]
+          settings.client, settings.user, options[:since_date], options[:until_date]
         ).collect
-      end
-
-      def client
-        @client ||= Octokit::Client.new(login: settings.user, access_token: settings.access_token)
       end
 
       def settings

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -19,7 +19,7 @@ module Github
       def list
         lines = []
         mutex = Mutex.new
-        format = Format.new(settings.client, settings, debug)
+        format = Format.new(settings, debug)
 
         Parallel.each_with_index(user_events, in_threads: settings.thread_num) do |user_event, i|
           # Contain GitHub access.
@@ -33,7 +33,7 @@ module Github
 
       desc 'init', 'Synchronize github-nippou settings on your gist'
       def init
-        Init.new(client: settings.client, settings: settings).run
+        Init.new(settings: settings).run
       end
 
       desc 'open-settings', 'Open settings url with web browser'

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -15,7 +15,7 @@ module Github
                    aliases: :u, desc: 'Retrieves GitHub user_events until the date'
       class_option :debug, type: :boolean, default: false, aliases: :d, desc: 'Debug mode'
 
-      desc 'list', "Displays today's GitHub events formatted for Nippou (Default)"
+      desc 'list', "Print today's your GitHub action (Default)"
       def list
         lines = []
         mutex = Mutex.new
@@ -31,7 +31,7 @@ module Github
         puts format.all(lines)
       end
 
-      desc 'init', 'Synchronize github-nippou settings on your gist'
+      desc 'init', 'Initialize github-nippou settings'
       def init
         Init.new(settings: settings).run
       end
@@ -42,7 +42,7 @@ module Github
         Launchy.open(settings.url)
       end
 
-      desc 'version', 'Displays version'
+      desc 'version', 'Print version'
       def version
         puts VERSION
       end

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -59,6 +59,10 @@ module Github
         @client ||= Octokit::Client.new(login: user, access_token: access_token)
       end
 
+      # Getting GitHub user
+      #
+      # @return [String]
+      # @raise [SystemExit] cannot get the user
       def user
         @user ||=
           case
@@ -73,10 +77,14 @@ module Github
               Please set github-nippou.user to your `~/.gitconfig`.
                   $ git config --global github-nippou.user [Your GitHub account]
             MESSAGE
-            exit!
+            abort
           end
       end
 
+      # Getting GitHub personal access token
+      #
+      # @return [String]
+      # @raise [SystemExit] cannot get the access token
       def access_token
         @access_token ||=
           case
@@ -94,7 +102,7 @@ module Github
               To get new token with `repo` and `gist` scope, visit
               https://github.com/settings/tokens/new
             MESSAGE
-            exit!
+            abort
           end
       end
 

--- a/lib/github/nippou/commands.rb
+++ b/lib/github/nippou/commands.rb
@@ -19,9 +19,9 @@ module Github
       def list
         lines = []
         mutex = Mutex.new
-        format = Format.new(client, thread_num, settings, debug)
+        format = Format.new(client, settings.thread_num, settings, debug)
 
-        Parallel.each_with_index(user_events, in_threads: thread_num) do |user_event, i|
+        Parallel.each_with_index(user_events, in_threads: settings.thread_num) do |user_event, i|
           # Contain GitHub access.
           # So should not put into the mutex block.
           line = format.line(user_event, i)
@@ -51,75 +51,16 @@ module Github
 
       def user_events
         @user_events ||= UserEvents.new(
-          client, user, options[:since_date], options[:until_date]
+          client, settings.user, options[:since_date], options[:until_date]
         ).collect
       end
 
       def client
-        @client ||= Octokit::Client.new(login: user, access_token: access_token)
-      end
-
-      # Getting GitHub user
-      #
-      # @return [String]
-      # @raise [SystemExit] cannot get the user
-      def user
-        @user ||=
-          case
-          when ENV['GITHUB_NIPPOU_USER']
-            ENV['GITHUB_NIPPOU_USER']
-          when !`git config github-nippou.user`.chomp.empty?
-            `git config github-nippou.user`.chomp
-          else
-            puts <<~MESSAGE
-              ** User required.
-
-              Please set github-nippou.user to your `~/.gitconfig`.
-                  $ git config --global github-nippou.user [Your GitHub account]
-            MESSAGE
-            abort
-          end
-      end
-
-      # Getting GitHub personal access token
-      #
-      # @return [String]
-      # @raise [SystemExit] cannot get the access token
-      def access_token
-        @access_token ||=
-          case
-          when ENV['GITHUB_NIPPOU_ACCESS_TOKEN']
-            ENV['GITHUB_NIPPOU_ACCESS_TOKEN']
-          when !`git config github-nippou.token`.chomp.empty?
-            `git config github-nippou.token`.chomp
-          else
-            puts <<~MESSAGE
-              ** Authorization required.
-
-              Please set github-nippou.token to your `~/.gitconfig`.
-                  $ git config --global github-nippou.token [Your GitHub access token]
-
-              To get new token with `repo` and `gist` scope, visit
-              https://github.com/settings/tokens/new
-            MESSAGE
-            abort
-          end
+        @client ||= Octokit::Client.new(login: settings.user, access_token: settings.access_token)
       end
 
       def settings
-        @settings ||= Settings.new(client: client)
-      end
-
-      def thread_num
-        @thread_num ||=
-          case
-          when ENV['GITHUB_NIPPOU_THREAD_NUM']
-            ENV['GITHUB_NIPPOU_THREAD_NUM']
-          when !`git config github-nippou.thread-num`.chomp.empty?
-            `git config github-nippou.thread-num`.chomp
-          else
-            5
-          end.to_i
+        @settings ||= Settings.new
       end
 
       def debug

--- a/lib/github/nippou/format.rb
+++ b/lib/github/nippou/format.rb
@@ -5,18 +5,16 @@ module Github
       using StringMarkdown
 
       # @param client [Octokit::Client]
-      # @param thread_num [Integer]
       # @param settings [Settings]
       # @param debug [Boolean]
-      def initialize(client, thread_num, settings, debug)
+      def initialize(client, settings, debug)
         @client = client
-        @thread_num = thread_num
         @settings = settings
         @debug = debug
       end
 
       def line(user_event, i)
-        STDERR.puts "#{i % @thread_num} : #{user_event.html_url}\n" if @debug
+        STDERR.puts "#{i % settings.thread_num} : #{user_event.html_url}\n" if @debug
         issue = issue(user_event)
 
         line = {

--- a/lib/github/nippou/format.rb
+++ b/lib/github/nippou/format.rb
@@ -4,11 +4,9 @@ module Github
       using SawyerResourceGithub
       using StringMarkdown
 
-      # @param client [Octokit::Client]
       # @param settings [Settings]
       # @param debug [Boolean]
-      def initialize(client, settings, debug)
-        @client = client
+      def initialize(settings, debug)
         @settings = settings
         @debug = debug
       end
@@ -60,12 +58,12 @@ module Github
       def issue(user_event)
         case
         when user_event.payload.pull_request
-          @client.pull_request(user_event.repo.name, user_event.payload.pull_request.number)
+          settings.client.pull_request(user_event.repo.name, user_event.payload.pull_request.number)
         when user_event.payload.issue.pull_request
           # a pull_request like an issue
-          @client.pull_request(user_event.repo.name, user_event.payload.issue.number)
+          settings.client.pull_request(user_event.repo.name, user_event.payload.issue.number)
         else
-          @client.issue(user_event.repo.name, user_event.payload.issue.number)
+          settings.client.issue(user_event.repo.name, user_event.payload.issue.number)
         end
       end
 

--- a/lib/github/nippou/init.rb
+++ b/lib/github/nippou/init.rb
@@ -3,10 +3,8 @@ require 'highline/import'
 module Github
   module Nippou
     class Init
-      # @param client [Octokit::Client]
       # @param settings [Settings]
-      def initialize(client:, settings:)
-        @client = client
+      def initialize(settings:)
         @settings = settings
       end
 
@@ -15,7 +13,7 @@ module Github
       # @raise [SystemExit] failed the initialization,
       #   or don't need, or canceled
       def run
-        unless client.scopes.include? 'gist'
+        unless settings.client.scopes.include? 'gist'
           puts <<~MESSAGE
             ** Gist scope required.
 
@@ -57,7 +55,7 @@ module Github
 
       private
 
-      attr_reader :client, :settings
+      attr_reader :settings
     end
   end
 end

--- a/lib/github/nippou/init.rb
+++ b/lib/github/nippou/init.rb
@@ -12,7 +12,8 @@ module Github
 
       # Run the initialization
       #
-      # @raise [SystemExit] don't need the initialization, or canceled
+      # @raise [SystemExit] failed the initialization,
+      #   or don't need, or canceled
       def run
         unless client.scopes.include? 'gist'
           puts <<~MESSAGE
@@ -22,7 +23,7 @@ module Github
             Please add `gist` scope to your personal access token, visit
             https://github.com/settings/tokens
           MESSAGE
-          exit!
+          abort
         end
 
         if settings.gist_id.present?

--- a/lib/github/nippou/init.rb
+++ b/lib/github/nippou/init.rb
@@ -1,0 +1,62 @@
+require 'highline/import'
+
+module Github
+  module Nippou
+    class Init
+      # @param client [Octokit::Client]
+      # @param settings [Settings]
+      def initialize(client:, settings:)
+        @client = client
+        @settings = settings
+      end
+
+      # Run the initialization
+      #
+      # @raise [SystemExit] don't need the initialization, or canceled
+      def run
+        unless client.scopes.include? 'gist'
+          puts <<~MESSAGE
+            ** Gist scope required.
+
+            You need personal access token which has `gist` scope.
+            Please add `gist` scope to your personal access token, visit
+            https://github.com/settings/tokens
+          MESSAGE
+          exit!
+        end
+
+        if settings.gist_id.present?
+          puts <<~MESSAGE
+            ** Already initialized.
+
+            Your `~/.gitconfig` already has gist_id as `github-nippou.settings-gist-id`.
+          MESSAGE
+          exit
+        end
+
+        puts 'This command will create a gist and update your `~/.gitconfig`.'
+
+        unless HighLine.agree('Are you sure? [y/n] ')
+          puts 'Canceled.'
+          abort
+        end
+
+        gist = settings.create_gist
+        `git config --global github-nippou.settings-gist-id #{gist.id}`
+
+        puts <<~MESSAGE
+          The github-nippou settings was created on #{gist.html_url}
+
+          And the gist_id was appended to your `~/.gitconfig`. You can
+          check the gist_id with following command.
+
+              $ git config --global github-nippou.settings-gist-id
+        MESSAGE
+      end
+
+      private
+
+      attr_reader :client, :settings
+    end
+  end
+end

--- a/lib/github/nippou/init.rb
+++ b/lib/github/nippou/init.rb
@@ -13,49 +13,153 @@ module Github
       # @raise [SystemExit] failed the initialization,
       #   or don't need, or canceled
       def run
-        unless settings.client.scopes.include? 'gist'
-          puts <<~MESSAGE
-            ** Gist scope required.
-
-            You need personal access token which has `gist` scope.
-            Please add `gist` scope to your personal access token, visit
-            https://github.com/settings/tokens
-          MESSAGE
-          abort
-        end
-
-        if settings.gist_id.present?
-          puts <<~MESSAGE
-            ** Already initialized.
-
-            Your `~/.gitconfig` already has gist_id as `github-nippou.settings-gist-id`.
-          MESSAGE
-          exit
-        end
-
-        puts 'This command will create a gist and update your `~/.gitconfig`.'
-
-        unless HighLine.agree('Are you sure? [y/n] ')
-          puts 'Canceled.'
-          abort
-        end
-
-        gist = settings.create_gist
-        `git config --global github-nippou.settings-gist-id #{gist.id}`
-
-        puts <<~MESSAGE
-          The github-nippou settings was created on #{gist.html_url}
-
-          And the gist_id was appended to your `~/.gitconfig`. You can
-          check the gist_id with following command.
-
-              $ git config --global github-nippou.settings-gist-id
-        MESSAGE
+        puts '** github-nippou Initialization **'
+        set_user!
+        sleep 0.5
+        set_access_token!
+        sleep 0.5
+        create_and_set_gist!
       end
 
       private
 
       attr_reader :settings
+
+      def set_user!
+        puts <<~MESSAGE
+
+          == [Step: 1/3] GitHub user ==
+
+        MESSAGE
+
+        begin
+          settings.user(verbose: false)
+          msg = 'Already initialized.'
+        rescue Github::Nippou::Settings::GettingUserError
+          user = HighLine.new.ask("What's your GitHub account? ")
+
+          if user.present?
+            puts <<~MESSAGE
+
+              The following command will be executed.
+
+                  $ git config --global github-nippou.user #{user}
+
+            MESSAGE
+
+            unless HighLine.agree('Are you sure? [y/n] ')
+              puts 'Canceled.'
+              abort
+            end
+
+            `git config --global github-nippou.user #{user}`
+            msg = 'Thanks!'
+          end
+        end
+
+        puts <<~MESSAGE
+          #{msg} You can get it with the following command.
+
+              $ git config --global github-nippou.user
+
+        MESSAGE
+      end
+
+      def set_access_token!
+        puts <<~MESSAGE
+
+          == [Step: 2/3] GitHub personal access token ==
+
+          To get new token with `repo` and `gist` scope, visit
+          https://github.com/settings/tokens/new
+
+        MESSAGE
+
+        begin
+          settings.access_token(verbose: false)
+          msg = 'Already initialized.'
+        rescue Github::Nippou::Settings::GettingAccessTokenError
+          token = HighLine.new.ask("What's your GitHub personal access token? ")
+
+          if token.present?
+            puts <<~MESSAGE
+
+              The following command will be executed.
+
+                  $ git config --global github-nippou.token #{token}
+
+            MESSAGE
+
+            unless HighLine.agree('Are you sure? [y/n] ')
+              puts 'Canceled.'
+              abort
+            end
+
+            `git config --global github-nippou.token #{token}`
+            msg = 'Thanks!'
+          end
+        end
+
+        puts <<~MESSAGE
+          #{msg} You can get it with the following command.
+
+              $ git config --global github-nippou.token
+
+        MESSAGE
+
+        unless settings.client.scopes.include?('repo') &&
+               settings.client.scopes.include?('gist')
+          puts <<~MESSAGE
+            !!!! `repo` and `gist` scopes are required. !!!!
+
+            You need personal access token which has `repo` and `gist`
+            scopes. Please add these scopes to your personal access
+            token, visit https://github.com/settings/tokens
+
+          MESSAGE
+          abort
+        end
+      end
+
+      def create_and_set_gist!
+        puts <<~MESSAGE
+
+          == [Step: 3/3] Gist (optional) ==
+
+        MESSAGE
+
+        if settings.gist_id.present?
+          msg = 'Already initialized.'
+        else
+          puts <<~MESSAGE
+            1. Create a gist with the content of #{settings.default_url}
+            2. The following command will be executed
+
+                $ git config --global github-nippou.settings-gist-id <created gist id>
+
+          MESSAGE
+
+          unless HighLine.agree('Are you sure? [y/n] ')
+            puts 'Canceled.'
+            abort
+          end
+
+          gist = settings.create_gist
+          `git config --global github-nippou.settings-gist-id #{gist.id}`
+          msg = 'Thanks!'
+        end
+
+        puts <<~MESSAGE
+          #{msg} You can get it with the following command.
+
+              $ git config --global github-nippou.settings-gist-id
+
+          And you can easily open the gist URL with web browser.
+
+              $ github-nippou open-settings
+
+        MESSAGE
+      end
     end
   end
 end

--- a/lib/github/nippou/settings.rb
+++ b/lib/github/nippou/settings.rb
@@ -80,6 +80,13 @@ module Github
           end.to_i
       end
 
+      # Getting Octokit client
+      #
+      # return [Octokit::Client]
+      def client
+        @client ||= Octokit::Client.new(login: user, access_token: access_token)
+      end
+
       # Create gist with config/settings.yml
       #
       # @return [Sawyer::Resource]
@@ -118,13 +125,6 @@ module Github
       end
 
       private
-
-      # Getting Octokit client
-      #
-      # return [Octokit::Client]
-      def client
-        @client ||= Octokit::Client.new(login: user, access_token: access_token)
-      end
 
       # Getting default settings.yml as Hash
       #

--- a/spec/github/nippou/init_spec.rb
+++ b/spec/github/nippou/init_spec.rb
@@ -1,0 +1,8 @@
+describe Github::Nippou::Init do
+  let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
+  let(:settings) { double(:settings, gist_id: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
+  let(:init) { described_class.new(client: client, settings: settings) }
+
+  it_behaves_like 'a settings interface'
+  it_behaves_like 'a init interface'
+end

--- a/spec/github/nippou/init_spec.rb
+++ b/spec/github/nippou/init_spec.rb
@@ -1,6 +1,7 @@
 describe Github::Nippou::Init do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
-  let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil, client: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
+  let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil,
+                          client: nil, create_gist: nil, url: nil, default_url: nil, format: nil, dictionary: nil) }
   let(:init) { described_class.new(settings: settings) }
 
   it_behaves_like 'a settings interface'

--- a/spec/github/nippou/init_spec.rb
+++ b/spec/github/nippou/init_spec.rb
@@ -1,6 +1,6 @@
 describe Github::Nippou::Init do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
-  let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
+  let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil, client: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
   let(:init) { described_class.new(client: client, settings: settings) }
 
   it_behaves_like 'a settings interface'

--- a/spec/github/nippou/init_spec.rb
+++ b/spec/github/nippou/init_spec.rb
@@ -1,7 +1,7 @@
 describe Github::Nippou::Init do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
   let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil, client: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
-  let(:init) { described_class.new(client: client, settings: settings) }
+  let(:init) { described_class.new(settings: settings) }
 
   it_behaves_like 'a settings interface'
   it_behaves_like 'a init interface'

--- a/spec/github/nippou/init_spec.rb
+++ b/spec/github/nippou/init_spec.rb
@@ -1,6 +1,6 @@
 describe Github::Nippou::Init do
   let(:client) { Octokit::Client.new(login: 'taro', access_token: '1234abcd') }
-  let(:settings) { double(:settings, gist_id: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
+  let(:settings) { double(:settings, user: nil, access_token: nil, gist_id: nil, thread_num: nil, create_gist: nil, url: nil, format: nil, dictionary: nil) }
   let(:init) { described_class.new(client: client, settings: settings) }
 
   it_behaves_like 'a settings interface'

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -53,6 +53,11 @@ describe Github::Nippou::Settings do
     end
   end
 
+  describe '#default_url' do
+    subject { settings.default_url }
+    it { is_expected.to eq "https://github.com/masutaka/github-nippou/blob/v#{Github::Nippou::VERSION}/config/settings.yml" }
+  end
+
   describe '#format' do
     before do
       allow(settings).to receive(:gist_id).and_return '12345'

--- a/spec/github/nippou/settings_spec.rb
+++ b/spec/github/nippou/settings_spec.rb
@@ -4,17 +4,13 @@ describe Github::Nippou::Settings do
 
   after { ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = nil }
 
+  it_behaves_like 'a settings interface'
+
   describe '#gist_id' do
     before { ENV['GITHUB_NIPPOU_SETTINGS_GIST_ID'] = '0123456789' }
 
     it 'is valid' do
       expect(settings.gist_id).to eq '0123456789'
-    end
-  end
-
-  describe '#create_gist' do
-    it 'responds to #create_gist' do
-      expect(settings).to respond_to :create_gist
     end
   end
 

--- a/spec/support/interface_init.rb
+++ b/spec/support/interface_init.rb
@@ -1,0 +1,4 @@
+shared_examples_for 'a init interface' do
+  subject { init }
+  it { is_expected.to respond_to :run }
+end

--- a/spec/support/interface_settings.rb
+++ b/spec/support/interface_settings.rb
@@ -1,6 +1,9 @@
 shared_examples_for 'a settings interface' do
   subject { settings }
+  it { is_expected.to respond_to :user }
+  it { is_expected.to respond_to :access_token }
   it { is_expected.to respond_to :gist_id }
+  it { is_expected.to respond_to :thread_num }
   it { is_expected.to respond_to :create_gist }
   it { is_expected.to respond_to :url }
   it { is_expected.to respond_to :format }

--- a/spec/support/interface_settings.rb
+++ b/spec/support/interface_settings.rb
@@ -4,6 +4,7 @@ shared_examples_for 'a settings interface' do
   it { is_expected.to respond_to :access_token }
   it { is_expected.to respond_to :gist_id }
   it { is_expected.to respond_to :thread_num }
+  it { is_expected.to respond_to :client }
   it { is_expected.to respond_to :create_gist }
   it { is_expected.to respond_to :url }
   it { is_expected.to respond_to :format }

--- a/spec/support/interface_settings.rb
+++ b/spec/support/interface_settings.rb
@@ -7,6 +7,7 @@ shared_examples_for 'a settings interface' do
   it { is_expected.to respond_to :client }
   it { is_expected.to respond_to :create_gist }
   it { is_expected.to respond_to :url }
+  it { is_expected.to respond_to :default_url }
   it { is_expected.to respond_to :format }
   it { is_expected.to respond_to :dictionary }
 end

--- a/spec/support/interface_settings.rb
+++ b/spec/support/interface_settings.rb
@@ -1,0 +1,8 @@
+shared_examples_for 'a settings interface' do
+  subject { settings }
+  it { is_expected.to respond_to :gist_id }
+  it { is_expected.to respond_to :create_gist }
+  it { is_expected.to respond_to :url }
+  it { is_expected.to respond_to :format }
+  it { is_expected.to respond_to :dictionary }
+end


### PR DESCRIPTION
Merge the following command in [Setup in README.md](https://github.com/masutaka/github-nippou/blob/v3.1.0/README.md#setup) to sub command `init`

    $ git config --global github-nippou.user [Your GitHub account]
    $ git config --global github-nippou.token [Your GitHub access token]

## Before

```
$ bundle exec bin/github-nippou init
This command will create a gist and update your `~/.gitconfig`.
Are you sure? [y/n] y
The github-nippou settings was created on https://gist.github.com/1a1f0598a7144842881c3d0a02158b31

And the gist_id was appended to your `~/.gitconfig`. You can
check the gist_id with following command.

    $ git config --global github-nippou.settings-gist-id
```

Sub command `init` has an ability of idempotency.

```
$ bundle exec bin/github-nippou init
** Already initialized.

Your `~/.gitconfig` already has gist_id as `github-nippou.settings-gist-id`.
```

## After

`github-nippou.user` and `github-nippou.token` in ~/.gitconfig are updated by sub command `init`.


```
$ bundle exec bin/github-nippou init
** github-nippou Initialization **

== [Step: 1/3] GitHub user ==

What's your GitHub account? masutaka

The following command will be executed.

    $ git config --global github-nippou.user masutaka

Are you sure? [y/n] y
Thanks! You can get it with the following command.

    $ git config --global github-nippou.user


== [Step: 2/3] GitHub personal access token ==

To get new token with `repo` and `gist` scope, visit
https://github.com/settings/tokens/new

What's your GitHub personal access token? ********

The following command will be executed.

    $ git config --global github-nippou.token ********

Are you sure? [y/n] y
Thanks! You can get it with the following command.

    $ git config --global github-nippou.token


== [Step: 3/3] Gist (optional) ==

1. Create a gist with the content of https://github.com/masutaka/github-nippou/blob/v3.1.0/config/settings.yml
2. The following command will be executed

    $ git config --global github-nippou.settings-gist-id <created gist id>

Are you sure? [y/n] y
Thanks! You can get it with the following command.

    $ git config --global github-nippou.settings-gist-id

And you can easily open the gist URL with web browser.

    $ github-nippou open-settings

```

Sub command `init` has an ability of idempotency even after the change.

```
$ bundle exec bin/github-nippou init
** github-nippou Initialization **

== [Step: 1/3] GitHub user ==

Already initialized. You can get it with the following command.

    $ git config --global github-nippou.user


== [Step: 2/3] GitHub personal access token ==

To get new token with `repo` and `gist` scope, visit
https://github.com/settings/tokens/new

Already initialized. You can get it with the following command.

    $ git config --global github-nippou.token


== [Step: 3/3] Gist (optional) ==

Already initialized. You can get it with the following command.

    $ git config --global github-nippou.settings-gist-id

And you can easily open the gist URL with web browser.

    $ github-nippou open-settings

```
