### PR TITLE
Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ $(NAME): lib/bindata.go $(SRCS)
 	go build -o $(NAME)
 
 lib/bindata.go: $(CONFIGS)
-	go-bindata -nocompress -pkg lib -o lib/bindata.go config
+	go generate
 
 # Install binary to $GOPATH/bin
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ CONFIGS := $(wildcard config/*)
 VERSION := v$(shell grep 'const Version ' lib/version.go | sed -E 's/.*"(.+)"$$/\1/')
 PACKAGES := $(shell go list ./...)
 
+ifeq (Windows_NT, $(OS))
+NAME := $(NAME).exe
+endif
+
 all: $(NAME)
 
 # Install dependencies for development

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 package main
 
+//go:generate go-bindata -nocompress -pkg lib -o lib/bindata.go config
+
 import (
 	"fmt"
 	"os"


### PR DESCRIPTION
* Windows の場合に exe ファイルの拡張子を足すようにしました。
* go generate で出力する様にしました。

個人的には、lib/bindata.go をリポジトリに含めて `go get github.com/masutaka/github-nippou` でインストール出来る方が便利だなと思いました。(.gitignore に書かれているので意図的なのかなと思いました)