### PR TITLE
Use event's Issue/PullRequest when user doesn't have permission to the repositories

### DIFF
--- a/lib/format.go
+++ b/lib/format.go
@@ -47,40 +47,72 @@ func (f *Format) Line(event *github.Event, i int) Line {
 		e := payload.(*github.IssuesEvent)
 		issue := getIssue(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
 
-		if issue.PullRequestLinks == nil {
-			line = Line{
-				title:    *issue.Title,
-				repoName: *event.Repo.Name,
-				url:      *issue.HTMLURL,
-				user:     *issue.User.Login,
-				status:   getIssueStatus(issue),
+		if issue != nil {
+			if issue.PullRequestLinks == nil {
+				line = Line{
+					title:    *issue.Title,
+					repoName: *event.Repo.Name,
+					url:      *issue.HTMLURL,
+					user:     *issue.User.Login,
+					status:   getIssueStatus(issue),
+				}
+			} else {
+				pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
+
+				line = Line{
+					title:    *pr.Title,
+					repoName: *event.Repo.Name,
+					url:      *pr.HTMLURL,
+					user:     *pr.User.Login,
+					status:   getPullRequestStatus(pr),
+				}
 			}
 		} else {
-			pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
-
 			line = Line{
-				title:    *pr.Title,
+				title:    *e.Issue.Title,
 				repoName: *event.Repo.Name,
-				url:      *pr.HTMLURL,
-				user:     *pr.User.Login,
-				status:   getPullRequestStatus(pr),
+				url:      *e.Issue.HTMLURL,
+				user:     *e.Issue.User.Login,
+				status:   getIssueStatus(e.Issue),
 			}
 		}
 	case "IssueCommentEvent":
 		e := payload.(*github.IssueCommentEvent)
 		issue := getIssue(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
 
-		if issue.PullRequestLinks == nil {
-			line = Line{
-				title:    *issue.Title,
-				repoName: *event.Repo.Name,
-				url:      *issue.HTMLURL,
-				user:     *issue.User.Login,
-				status:   getIssueStatus(issue),
+		if issue != nil {
+			if issue.PullRequestLinks == nil {
+				line = Line{
+					title:    *issue.Title,
+					repoName: *event.Repo.Name,
+					url:      *issue.HTMLURL,
+					user:     *issue.User.Login,
+					status:   getIssueStatus(issue),
+				}
+			} else {
+				pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
+
+				line = Line{
+					title:    *pr.Title,
+					repoName: *event.Repo.Name,
+					url:      *pr.HTMLURL,
+					user:     *pr.User.Login,
+					status:   getPullRequestStatus(pr),
+				}
 			}
 		} else {
-			pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, *e.Issue.Number)
-
+			line = Line{
+				title:    *e.Issue.Title,
+				repoName: *event.Repo.Name,
+				url:      *e.Issue.HTMLURL,
+				user:     *e.Issue.User.Login,
+				status:   getIssueStatus(e.Issue),
+			}
+		}
+	case "PullRequestEvent":
+		e := payload.(*github.PullRequestEvent)
+		pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, e.GetNumber())
+		if pr != nil {
 			line = Line{
 				title:    *pr.Title,
 				repoName: *event.Repo.Name,
@@ -88,16 +120,14 @@ func (f *Format) Line(event *github.Event, i int) Line {
 				user:     *pr.User.Login,
 				status:   getPullRequestStatus(pr),
 			}
-		}
-	case "PullRequestEvent":
-		e := payload.(*github.PullRequestEvent)
-		pr := getPullRequest(f.ctx, f.client, *event.Repo.Name, e.GetNumber())
-		line = Line{
-			title:    *pr.Title,
-			repoName: *event.Repo.Name,
-			url:      *pr.HTMLURL,
-			user:     *pr.User.Login,
-			status:   getPullRequestStatus(pr),
+		} else {
+			line = Line{
+				title:    *e.PullRequest.Title,
+				repoName: *event.Repo.Name,
+				url:      *e.PullRequest.HTMLURL,
+				user:     *e.PullRequest.User.Login,
+				status:   getPullRequestStatus(e.PullRequest),
+			}
 		}
 	case "PullRequestReviewCommentEvent":
 		e := payload.(*github.PullRequestReviewCommentEvent)


### PR DESCRIPTION
## 概要

現時点でアクセス権が無いレポジトリの Issue, PR が action に含まれる場合のエラーを回避する修正です。

## 詳細

現時点でアクセス権が無いレポジトリの Issue, PR が action に含まれる場合、以下のように runtime error になります。

```shell
$ github-nippou -s 20180314 -u 20180314
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0x1346018]

goroutine 53 [running]:
github.com/masutaka/github-nippou/lib.(*Format).Line(0xc4204e0f80, 0xc4202fdd40, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/masutaka/src/github.com/masutaka/github-nippou/lib/format.go:73 +0x8d8
github.com/masutaka/github-nippou/lib.List.func1(0xc42017d620, 0xc4204bce10, 0xc4204e0f80, 0xc42017d618, 0xc4204e10c0, 0xc4202fdd40, 0x3)
	/Users/masutaka/src/github.com/masutaka/github-nippou/lib/list.go:56 +0xa4
created by github.com/masutaka/github-nippou/lib.List
	/Users/masutaka/src/github.com/masutaka/github-nippou/lib/list.go:53 +0x44c
```

そこで `getIssue`, `getPullRequest` で取得に失敗した場合は event が持つ `Issue`, `PullRequest` を代わりに使うようにしました。