### PR TITLE
maintenance: Use event.ParsePayload() instead of deprecated event.Payload()

### DIFF
--- a/lib/list.go
+++ b/lib/list.go
@@ -35,7 +35,10 @@ func List(sinceDate, untilDate string, debug bool) error {
 	ctx := context.Background()
 	client := getClient(ctx, accessToken)
 
-	events := NewEvents(ctx, client, user, sinceTime, untilTime, debug).Collect()
+	events, err := NewEvents(ctx, client, user, sinceTime, untilTime, debug).Collect()
+	if err != nil {
+		return err
+	}
 	format := NewFormat(ctx, client, debug)
 
 	parallelNum, err := getParallelNum()


### PR DESCRIPTION
`event.Payload()` は非推奨になっていたため、代替先の `event.ParsePayload()` に切り替えました。

ref: https://pkg.go.dev/github.com/google/go-github@v17.0.0+incompatible/github#Event.Payload

## 動作確認

- `make dist` でビルドしたパッケージを実行し( `./pkg/darwin_arm64/github-nippou` )、変わらず動作することを確認しています。
- 手元で `make test-all` が通ることを確認しています。