### PR TITLE
refactor(lib): Remove environment variable dependencies from `Settings.Init()` and `Format.All()`

### DIFF
--- a/lib/events.go
+++ b/lib/events.go
@@ -88,7 +88,7 @@ func (e *Events) filter(events []*github.Event) []*github.Event {
 
 	for _, event := range events {
 		if e.debug {
-			format := NewFormat(e.ctx, e.client, false)
+			format := NewFormat(e.ctx, e.client, Settings{}, false)
 			fmt.Printf("[Debug] %s: %v\n", *event.Type, format.Line(event, 999))
 		}
 

--- a/lib/format.go
+++ b/lib/format.go
@@ -164,7 +164,11 @@ func (f *Format) All(lines Lines) (string, error) {
 	var result, prevRepoName, currentRepoName string
 	var settings Settings
 
-	if err := settings.Init(); err != nil {
+	accessToken, err := getAccessToken()
+	if err != nil {
+		return "", err
+	}
+	if err := settings.Init(getGistID(), accessToken); err != nil {
 		return "", err
 	}
 

--- a/lib/format.go
+++ b/lib/format.go
@@ -14,14 +14,15 @@ import (
 
 // Format is Formatter
 type Format struct {
-	ctx    context.Context
-	client *github.Client
-	debug  bool
+	ctx      context.Context
+	client   *github.Client
+	settings Settings
+	debug    bool
 }
 
 // NewFormat is an initializer
-func NewFormat(ctx context.Context, client *github.Client, debug bool) *Format {
-	return &Format{ctx: ctx, client: client, debug: debug}
+func NewFormat(ctx context.Context, client *github.Client, settings Settings, debug bool) *Format {
+	return &Format{ctx: ctx, client: client, settings: settings, debug: debug}
 }
 
 // Line is line infomation
@@ -162,15 +163,6 @@ func getOwnerRepo(repoFullName string) (string, string) {
 // All returns all lines which are formatted and sorted
 func (f *Format) All(lines Lines) (string, error) {
 	var result, prevRepoName, currentRepoName string
-	var settings Settings
-
-	accessToken, err := getAccessToken()
-	if err != nil {
-		return "", err
-	}
-	if err := settings.Init(getGistID(), accessToken); err != nil {
-		return "", err
-	}
 
 	sort.Sort(lines)
 
@@ -179,10 +171,10 @@ func (f *Format) All(lines Lines) (string, error) {
 
 		if currentRepoName != prevRepoName {
 			prevRepoName = currentRepoName
-			result += fmt.Sprintf("\n%s\n\n", formatSubject(settings, currentRepoName))
+			result += fmt.Sprintf("\n%s\n\n", formatSubject(f.settings, currentRepoName))
 		}
 
-		result += fmt.Sprintf("%s\n", formatLine(settings, line))
+		result += fmt.Sprintf("%s\n", formatLine(f.settings, line))
 	}
 
 	return result, nil

--- a/lib/format_test.go
+++ b/lib/format_test.go
@@ -1,0 +1,50 @@
+package lib_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/masutaka/github-nippou/lib"
+)
+
+func TestFormatAll(t *testing.T) {
+	issue := github.Issue{
+		State:   github.String("closed"),
+		Title:   github.String("イベントを取得できないことがある"),
+		User:    &github.User{Login: github.String("masutaka")},
+		HTMLURL: github.String("https://github.com/masutaka/github-nippou/issues/1"),
+	}
+	pr := github.PullRequest{
+		State:   github.String("closed"),
+		Title:   github.String("Bundle Update on 2015-10-04"),
+		User:    &github.User{Login: github.String("deppbot")},
+		HTMLURL: github.String("https://github.com/masutaka/github-nippou/pull/31"),
+		Merged:  github.Bool(true),
+	}
+	lines := lib.Lines{
+		lib.NewLineByIssue("masutaka/github-nippou", issue),
+		lib.NewLineByPullRequest("masutaka/github-nippou", pr),
+	}
+	settings := lib.Settings{}
+	settings.Init("", "")
+
+	ctx := context.Background()
+	f := lib.NewFormat(ctx, nil, settings, false)
+
+	result, err := f.All(lines)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expected := `
+### masutaka/github-nippou
+
+* [イベントを取得できないことがある](https://github.com/masutaka/github-nippou/issues/1) by @[masutaka](https://github.com/masutaka) **closed!**
+* [Bundle Update on 2015-10-04](https://github.com/masutaka/github-nippou/pull/31) by @[deppbot](https://github.com/deppbot) **merged!**
+`
+
+	if result != expected {
+		t.Errorf("unexpected result: got %q, want %q", result, expected)
+	}
+}

--- a/lib/list.go
+++ b/lib/list.go
@@ -39,7 +39,11 @@ func List(sinceDate, untilDate string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	format := NewFormat(ctx, client, debug)
+	var settings Settings
+	if err = settings.Init(getGistID(), accessToken); err != nil {
+		return err
+	}
+	format := NewFormat(ctx, client, settings, debug)
 
 	parallelNum, err := getParallelNum()
 	if err != nil {

--- a/lib/open_settings.go
+++ b/lib/open_settings.go
@@ -10,7 +10,7 @@ import (
 func OpenSettings() error {
 	var settings Settings
 
-	if err := settings.Init(); err != nil {
+	if err := settings.Init(getGistID(), ""); err != nil {
 		return nil
 	}
 

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -35,22 +35,13 @@ type Settings struct {
 }
 
 // Init initializes Settings
-func (s *Settings) Init() error {
+func (s *Settings) Init(gistID string, accessToken string) error {
 	var content string
 	var err error
 
-	gistID := getGistID()
-
 	if gistID != "" {
 		ctx := context.Background()
-
-		accessToken, err := getAccessToken()
-		if err != nil {
-			return err
-		}
-
 		client := getClient(ctx, accessToken)
-
 		gist, _, err := client.Gists.Get(ctx, gistID)
 		if err != nil {
 			return err


### PR DESCRIPTION
- ref: https://github.com/masutaka/github-nippou/issues/110

ライブラリとしてのユースケースをサポートするために、各メソッドから環境変数やgit configへの依存を取り除いていきます。
今回はサンプルとして `Settings.Init()` と `Format.All()` について対応し、外側から情報を注入できるようにしました。

## 動作確認方法

以下の内容を確認しています。

- `make test-all` , `make lint` が通ること
- `make dist` を実施し、 `./pkg/darwin_arm64/github-nippou` が問題なく動作すること
