### PR TITLE
Fix broken `open-setting` sub command

### DIFF
--- a/lib/open_settings.go
+++ b/lib/open_settings.go
@@ -10,7 +10,12 @@ import (
 func OpenSettings() error {
 	var settings Settings
 
-	if err := settings.Init(getGistID(), ""); err != nil {
+	accessToken, err := getAccessToken()
+	if err != nil {
+		return err
+	}
+
+	if err := settings.Init(getGistID(), accessToken); err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
`$ github-nippou open-settings` でブラウザの反応がなくなってた。

なんだろう？と調べたら、`401 Bad credentials` が返っており、`settings.Init()` の第２引数に渡すべき accessToken が空文字列になっていた。

https://github.com/masutaka/github-nippou/blob/98d4a93684e6416c662bc3c5edb4e8826624e190/lib/open_settings.go#L13-L15

[v4.2.5](https://github.com/masutaka/github-nippou/releases/tag/v4.2.5) からのエンバグ。PR #116 の 02eb6c0f67a23b380114ba7ae33823fce0f18837 だったのね。

@MH4GF: レビューで漏れてて申し訳なかったです。:pray:
