### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/format.go
+++ b/lib/format.go
@@ -25,7 +25,7 @@ func NewFormat(ctx context.Context, client *github.Client, settings Settings, de
 	return &Format{ctx: ctx, client: client, settings: settings, debug: debug}
 }
 
-// Line is line infomation
+// Line is line information
 type Line struct {
 	title    string
 	repoName string


### PR DESCRIPTION
PR #133 で追加した [Go Report Card](https://goreportcard.com/report/github.com/masutaka/github-nippou/v4) の misspell 指摘で気がついた。