### PR TITLE
test: Does dependabot support commit hash?

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - id: run-tagpr
         uses: Songmu/tagpr@v1
         env:
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-tags: true
       - name: Setup Go environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Dependabot が以下のような指定もサポートしているかテストする。

    actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

コミットハッシュを指定するのは、サードパーティのツールを使う時のセキュアな方法。
例: [CI/CDでサードパーティスクリプト・バイナリを使う際の注意点 \- ROUTE06 Tech Blog](https://tech.route06.co.jp/entry/2023/08/23/082500)

本来 `actions/checkout` には使わなくても良い方法だと思うが、Dependabot が対応しているなら今後使っても良いかも。
