### PR TITLE
switch to action hash with version comment

### DIFF
--- a/.github/workflows/pushover.yml
+++ b/.github/workflows/pushover.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: pushover-actions
-      uses: umahmood/pushover-actions@v1.1.0
+      uses: umahmood/pushover-actions@5da31193f672e7418804bdb51836bdf20f393c8f # v1.1.0
       env:
         PUSHOVER_TOKEN: ${{ secrets.PUSHOVER_API_KEY }}
         PUSHOVER_USER: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@v4
       - id: run-tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@0a9b8e6634db66e773516828c1359dc6e9e8b484 # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
@@ -40,7 +40,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@v4
         with:
           fetch-tags: true
       - name: Setup Go environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@v4
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Related to https://github.com/masutaka/github-nippou/pull/154

Dependabot supports commit hash.

* https://github.com/dependabot/dependabot-core/pull/5951
* [Dependabot now updates comments in GitHub Actions workflows referencing action versions - The GitHub Blog](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/)

However, verified creators are excluded.
