### PR TITLE
Fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/pushover.yml
+++ b/.github/workflows/pushover.yml
@@ -2,6 +2,11 @@ name: Pushover
 
 on:
   workflow_call:
+    secrets:
+      PUSHOVER_API_KEY:
+        required: true
+      PUSHOVER_USER_KEY:
+        required: true
 
 jobs:
   pushover:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,6 @@ jobs:
     if: failure()
     needs: [release]
     uses: ./.github/workflows/pushover.yml
+    secrets:
+      PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
+      PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - Test
     types:
       - completed
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,6 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch && failure()
     needs: [actionlint, test]
     uses: ./.github/workflows/pushover.yml
+    secrets:
+      PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
+      PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}


### PR DESCRIPTION
Because pushover credentials were not passed, pushover always failed to post when workflow failed.