### PR TITLE
Bump google/go-github to v63

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/masutaka/github-nippou/v4
 go 1.22
 
 require (
-	github.com/google/go-github/v60 v60.0.0
+	github.com/google/go-github/v63 v63.0.0
 	github.com/rakyll/statik v0.1.7
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v60 v60.0.0 h1:oLG98PsLauFvvu4D/YPxq374jhSxFYdzQGNCyONLfn8=
-github.com/google/go-github/v60 v60.0.0/go.mod h1:ByhX2dP9XT9o/ll2yXAu2VD8l5eNVg8hD4Cr0S/LmQk=
+github.com/google/go-github/v63 v63.0.0 h1:13xwK/wk9alSokujB9lJkuzdmQuVn2QCPeck76wR3nE=
+github.com/google/go-github/v63 v63.0.0/go.mod h1:IqbcrgUmIcEaioWrGYei/09o+ge5vhffGOcxrO0AfmA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/lib/events.go
+++ b/lib/events.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v63/github"
 )
 
 // Events represents a structure for fetching user-related events from the GitHub API.

--- a/lib/format.go
+++ b/lib/format.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v63/github"
 )
 
 // Format is Formatter

--- a/lib/format_test.go
+++ b/lib/format_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v63/github"
 	"github.com/masutaka/github-nippou/v4/lib"
 )
 

--- a/lib/list.go
+++ b/lib/list.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v63/github"
 )
 
 // List is a struct for collecting GitHub activities.

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -13,7 +13,7 @@ import (
 	// Import ./config/*
 	_ "github.com/masutaka/github-nippou/v4/statik"
 
-	"github.com/google/go-github/v60/github"
+	"github.com/google/go-github/v63/github"
 	"github.com/rakyll/statik/fs"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
* https://github.com/google/go-github/releases/tag/v61.0.0
* https://github.com/google/go-github/releases/tag/v62.0.0
* https://github.com/google/go-github/releases/tag/v63.0.0
