### PR TITLE
Fix go toolchain version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ lint:
 # Bump go version
 .PHONY: bump_go_version
 bump_go_version:
-	@printf "go version? "; read version; \
-	go mod edit -go="$$(echo $$version | sed -e 's@\.[0-9]\+$$@@')"
+	@printf "go version (x.y.z)? "; read version; \
+	go mod edit -go="$$version"
 	go mod tidy
 
 # Generate binary archives for release check on local machine

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/masutaka/github-nippou/v4
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/google/go-github/v63 v63.0.0


### PR DESCRIPTION
After enabling CodeQL, the following error occurred:

<img width="1471" alt="Invalid Go toolchain version" src="https://github.com/user-attachments/assets/ff1e9105-9bf2-42ce-8688-dc0e95778cf4">

> Invalid Go toolchain version
>
> As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
>
> 1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

ref.
[\[修正済み\] go.modのgoディレクティブにパッチバージョンを含めないと「toolchain not available」と怒られる](https://zenn.dev/haruyama480/articles/7e3b00bfad69ae)
