### PR TITLE
Add CodeQL job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,24 @@
+name: Schedule
+
+on:
+  schedule:
+    - cron: "00 10 * * 5" # every friday 19:00 JST
+
+jobs:
+  codeql:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      security-events: write
+    uses: route06/actions/.github/workflows/codeql_core.yml@b4926a2cc01811c7908ded0a7d93f4b5527079d4 # v2.4.0
+    with:
+      language: "go"
+  pushover:
+    name: pushover if failure
+    if: github.ref_name == github.event.repository.default_branch && failure()
+    needs: codeql
+    uses: ./.github/workflows/pushover.yml
+    secrets:
+      PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
+      PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
   pushover:
     name: pushover if failure
     if: github.ref_name == github.event.repository.default_branch && failure()
-    needs: [actionlint, test]
+    needs: [actionlint, codeql, test]
     uses: ./.github/workflows/pushover.yml
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "00 10 * * 5" # Mainly for CodeQL, every fri 19:00 JST
 
 jobs:
   actionlint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,13 @@ jobs:
         filter_mode: nofilter
         level: error
         reporter: github-pr-review
+  codeql:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      security-events: write
+    uses: route06/actions/.github/workflows/codeql.yml@b4926a2cc01811c7908ded0a7d93f4b5527079d4 # v2.4.0
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: "00 10 * * 5" # Mainly for CodeQL, every fri 19:00 JST
 
 jobs:
   actionlint:


### PR DESCRIPTION
Since it is always slow to run CodeQL tests, optimize the timing of execution using [route06/actions](https://github.com/route06/actions).

* Run CodeQL only when necessary
* Run CodeQL every Friday
    * Since CodeQL is also executed on a scheduled basis
