### PR TITLE
Fix the GoReleaser deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_checksums.txt'
 
 snapshot:
-  name_template: "{{ .Version }}-next"
+  version_template: "{{ .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
🔗 https://github.com/masutaka/github-nippou/actions/runs/10991952626/job/30515379362

> DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
