### PR TITLE
Add NoritakaIkeda/GitJournal link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Print today's your GitHub activity for issues and pull requests.
 
 This is a helpful CLI when you write a daily report in reference to GitHub. Nippou is a japanese word which means a daily report.
 
-A web version of this CLI is also available at https://github.com/MH4GF/github-nippou-web .
-
 ## Installation
 
 Grab the latest binary from the [releases](https://github.com/masutaka/github-nippou/releases) page.
@@ -91,6 +89,15 @@ $ github-nippou
 * [Add sub command \`open-settings\`](https://github.com/masutaka/github-nippou/pull/65) by @[masutaka](https://github.com/masutaka) **merged!**
 * [Dockerize](https://github.com/masutaka/github-nippou/pull/66) by @[masutaka](https://github.com/masutaka) **merged!**
 ```
+
+## Usage Examples as a library
+
+The following projects use github-nippou as a library:
+
+* https://github.com/MH4GF/github-nippou-web
+    * A web app version of github-nippou
+* https://github.com/NoritakaIkeda/GitJournal
+    * A web app that can post github-nippou output to a GitHub Discussion
 
 ## Optional: Customize Output Format
 


### PR DESCRIPTION
## Related Issue

<!-- Mention the related issue number if applicable. -->

* closes https://github.com/masutaka/github-nippou/issues/232

## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at ac552fd8e0a23ecc983605b7c40173ef4775a1c0

['Documentation']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at ac552fd8e0a23ecc983605b7c40173ef4775a1c0

- Added a new section for usage examples as a library.
- Included a link to `NoritakaIkeda/GitJournal` in the README.
- Removed redundant mention of `github-nippou-web` from the introduction.


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated README with usage examples and links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added a new section titled "Usage Examples as a library".<br> <li> Included links to <code>github-nippou-web</code> and <code>NoritakaIkeda/GitJournal</code> under <br>the new section.<br> <li> Removed a redundant mention of <code>github-nippou-web</code> from the <br>introduction.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/239/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>