### PR TITLE
Bump google/go-github to v69

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/masutaka/github-nippou/v4
 go 1.22.5
 
 require (
-	github.com/google/go-github/v63 v63.0.0
+	github.com/google/go-github/v69 v69.0.0
 	github.com/rakyll/statik v0.1.7
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v63 v63.0.0 h1:13xwK/wk9alSokujB9lJkuzdmQuVn2QCPeck76wR3nE=
-github.com/google/go-github/v63 v63.0.0/go.mod h1:IqbcrgUmIcEaioWrGYei/09o+ge5vhffGOcxrO0AfmA=
+github.com/google/go-github/v69 v69.0.0 h1:YnFvZ3pEIZF8KHmI8xyQQe3mYACdkhnaTV2hr7CP2/w=
+github.com/google/go-github/v69 v69.0.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/lib/events.go
+++ b/lib/events.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/go-github/v63/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // Events represents a structure for fetching user-related events from the GitHub API.

--- a/lib/format.go
+++ b/lib/format.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/google/go-github/v63/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // Format is Formatter

--- a/lib/format_test.go
+++ b/lib/format_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v63/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/masutaka/github-nippou/v4/lib"
 )
 

--- a/lib/list.go
+++ b/lib/list.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v63/github"
+	"github.com/google/go-github/v69/github"
 )
 
 // List is a struct for collecting GitHub activities.

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -13,7 +13,7 @@ import (
 	// Import ./config/*
 	_ "github.com/masutaka/github-nippou/v4/statik"
 
-	"github.com/google/go-github/v63/github"
+	"github.com/google/go-github/v69/github"
 	"github.com/rakyll/statik/fs"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
## Related Issue

<!-- Mention the related issue number if applicable. -->

* closes https://github.com/masutaka/github-nippou/issues/231

## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 54005a3eda551e9a83351e4492e0d34db9a021e4

['Enhancement']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 54005a3eda551e9a83351e4492e0d34db9a021e4

- Updated `github.com/google/go-github` library from v63 to v69.
- Modified import statements in multiple files to reflect the updated library version.
- Updated `go.mod` and `go.sum` to include the new library version.
- Ran `go mod tidy` to clean up module dependencies.


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>events.go</strong><dd><code>Update import to `v69` in `events.go`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/events.go

<li>Updated import statement to use <code>v69</code> of <code>github.com/google/go-github</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-d4a1aa358b9d78cc7735e2523fb8d1dd7c4c437744c484e46c05069dde7b04df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format.go</strong><dd><code>Update import to `v69` in `format.go`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/format.go

<li>Updated import statement to use <code>v69</code> of <code>github.com/google/go-github</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-e3512fab70a6255e491d261a3d9e49928ba1d23f263e5c6efb860272a86ab15c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format_test.go</strong><dd><code>Update import to `v69` in `format_test.go`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/format_test.go

<li>Updated import statement to use <code>v69</code> of <code>github.com/google/go-github</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-7da326c2d64d344e97818c748f4d8377f2d92bc6fd757f5ad0375bb5dfd37fda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list.go</strong><dd><code>Update import to `v69` in `list.go`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/list.go

<li>Updated import statement to use <code>v69</code> of <code>github.com/google/go-github</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-b0e7a045f8cdefd27070c7bac2e2fd5278c68254ca91c9f95a80cf726bc66751">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.go</strong><dd><code>Update import to `v69` in `settings.go`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/settings.go

<li>Updated import statement to use <code>v69</code> of <code>github.com/google/go-github</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-90883f6646ec322ad52f4230142e1049f26152b305f94db54542b5877d723327">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update `go.mod` for `go-github` v69</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<li>Updated <code>github.com/google/go-github</code> dependency from <code>v63</code> to <code>v69</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update `go.sum` for `go-github` v69</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum

<li>Updated checksums for <code>github.com/google/go-github</code> to reflect version <br><code>v69</code>.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/240/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Other Information

<!-- Add any other relevant information for the reviewer. -->

* https://github.com/google/go-github/releases/tag/v64.0.0
* https://github.com/google/go-github/releases/tag/v65.0.0
* https://github.com/google/go-github/releases/tag/v66.0.0
* https://github.com/google/go-github/releases/tag/v67.0.0
* https://github.com/google/go-github/releases/tag/v68.0.0
* https://github.com/google/go-github/releases/tag/v69.0.0

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>