### PR TITLE
Fix goreleaser error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ builds:
     main: ./main.go
 
 archives:
-  - format: zip
+  - formats: [ "zip" ]
     name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [v4.2.34](https://github.com/masutaka/github-nippou/compare/v4.2.33...v4.2.34) - 2025-02-10
-### Maintenance :technologist:
-- Bump reviewdog/action-actionlint from 1.57.0 to 1.61.0 by @dependabot in https://github.com/masutaka/github-nippou/pull/233
-- Bump Songmu/tagpr from 1.5.0 to 1.5.1 by @dependabot in https://github.com/masutaka/github-nippou/pull/235
-- Bump reviewdog/action-actionlint from 1.61.0 to 1.64.1 by @dependabot in https://github.com/masutaka/github-nippou/pull/236
-- Bump golang.org/x/oauth2 from 0.24.0 to 0.25.0 by @dependabot in https://github.com/masutaka/github-nippou/pull/234
-- Fix the warning of reviewdog/action-actionlint by @masutaka in https://github.com/masutaka/github-nippou/pull/237
-- Bump google/go-github to v69 by @masutaka in https://github.com/masutaka/github-nippou/pull/240
-### Documentation :memo:
-- Update External articles in README.md by @masutaka in https://github.com/masutaka/github-nippou/pull/229
-- Add NoritakaIkeda/GitJournal link to README.md by @masutaka in https://github.com/masutaka/github-nippou/pull/239
-### Other Changes
-- Introduce PR-Agent by @masutaka in https://github.com/masutaka/github-nippou/pull/238
-
 ## [v4.2.33](https://github.com/masutaka/github-nippou/compare/v4.2.32...v4.2.33) - 2024-12-01
 ### Maintenance :technologist:
 - Introduce Dependency Review to CI by @masutaka in https://github.com/masutaka/github-nippou/pull/222

--- a/lib/version.go
+++ b/lib/version.go
@@ -1,4 +1,4 @@
 package lib
 
 // Version is the github-nippou version
-const Version = "4.2.34"
+const Version = "4.2.33"


### PR DESCRIPTION
## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 8ce07b412e414c2ad857b01dab4dba842d9306d4

['Bug fix', 'Enhancement']

## PR Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 8ce07b412e414c2ad857b01dab4dba842d9306d4

- Fixed deprecated property usage in `.goreleaser.yaml`.
- Reverted version bump to `4.2.34` in `lib/version.go`.
- Removed changelog entries for version `4.2.34`.


## PR Walkthrough

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.go</strong><dd><code>Revert version bump to `4.2.33`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/version.go

- Reverted the version from `4.2.34` to `4.2.33`.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/241/files#diff-5462267056b1cbe1a393afccfbf2c9a35ddb4fef7e25c95349d14ff51630ebe4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.goreleaser.yaml</strong><dd><code>Fix deprecated property in `.goreleaser.yaml`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.goreleaser.yaml

<li>Fixed deprecated <code>archives.format</code> property.<br> <li> Updated to use <code>archives.formats</code> array.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/241/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Remove changelog for version `4.2.34`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Removed changelog entries for version `4.2.34`.


</details>


  </td>
  <td><a href="https://github.com/masutaka/github-nippou/pull/241/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Other Information

<!-- Add any other relevant information for the reviewer. -->

I guess I was unaware of the destructive changes in goreleaser's update from v5 to v6.

* https://github.com/masutaka/github-nippou/pull/167

I don't want to create a broken release, so I reverted the commits in the v4.2.34 release PR and removed the git tags. I am not sure if this is the correct way to handle a failed release in tagpr.

* https://github.com/masutaka/github-nippou/pull/230

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>