### PR TITLE
chore: Substantially unlimit open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
       interval: "monthly"
       time: "19:00"
@@ -11,6 +12,7 @@ updates:
       default-days: 7
   - package-ecosystem: "gomod"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
       interval: "monthly"
       time: "19:00"


### PR DESCRIPTION
The default of open-pull-requests-limit is 5, but set it to 99 to substantially remove the limit.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
