### PR TITLE
Improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,7 @@ jobs:
     if: failure()
     needs: [release]
     uses: masutaka/actions/.github/workflows/pushover.yml@main
-    permissions:
-      contents: read
+    permissions: {}
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
       PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,7 +11,6 @@ jobs:
         language: [actions, go]
     permissions:
       actions: read
-      checks: read
       contents: read
       security-events: write
     uses: masutaka/actions/.github/workflows/codeql_core.yml@main
@@ -22,8 +21,7 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch && failure()
     needs: codeql
     uses: masutaka/actions/.github/workflows/pushover.yml@main
-    permissions:
-      contents: read
+    permissions: {}
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
       PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,21 +8,9 @@ on:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: masutaka/actions/.github/workflows/actionlint.yml@main
     permissions:
-      checks: write
       contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-      - name: Run actionlint
-        uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
-        with:
-          fail_level: error
-          filter_mode: nofilter
-          level: error
-          reporter: github-pr-review
   codeql:
     permissions:
       actions: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
   codeql:
     permissions:
       actions: read
-      checks: read
       contents: read
+      pull-requests: read
       security-events: write
     uses: masutaka/actions/.github/workflows/codeql.yml@main
   test:
@@ -35,8 +35,7 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch && failure()
     needs: [actionlint, codeql, test]
     uses: masutaka/actions/.github/workflows/pushover.yml@main
-    permissions:
-      contents: read
+    permissions: {}
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
       PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}


### PR DESCRIPTION
## Summary

- Replace `reviewdog/action-actionlint` with own reusable workflow (`masutaka/actions/.github/workflows/actionlint.yml@main`)
- Align caller-side permissions with the contract change in https://github.com/masutaka/actions/pull/30
  - Add `pull-requests: read` to the `codeql` caller so `dorny/paths-filter` can read PR files via the REST API
  - Drop over-privileged `checks: read` from the `codeql` and `codeql_core` callers
  - Narrow `pushover` caller permissions to `{}` since it only calls the Pushover API