### PR TITLE
Support DiscussionEvent

### DIFF
--- a/lib/events.go
+++ b/lib/events.go
@@ -93,7 +93,7 @@ func (e *Events) filter(events []*github.Event) []*github.Event {
 		}
 
 		switch *event.Type {
-		case "IssuesEvent", "IssueCommentEvent", "PullRequestEvent", "PullRequestReviewCommentEvent", "PullRequestReviewEvent":
+		case "IssuesEvent", "IssueCommentEvent", "PullRequestEvent", "PullRequestReviewCommentEvent", "PullRequestReviewEvent", "DiscussionEvent":
 			result = append(result, event)
 		}
 	}
@@ -147,6 +147,10 @@ func htmlURL(event *github.Event) (string, error) {
 	case "PullRequestReviewEvent":
 		if e := payload.(*github.PullRequestReviewEvent); e.PullRequest != nil && e.PullRequest.HTMLURL != nil {
 			result = *e.PullRequest.HTMLURL
+		}
+	case "DiscussionEvent":
+		if e := payload.(*github.DiscussionEvent); e.Discussion != nil && e.Discussion.HTMLURL != nil {
+			result = *e.Discussion.HTMLURL
 		}
 	}
 

--- a/lib/format.go
+++ b/lib/format.go
@@ -127,7 +127,12 @@ func (f *Format) Line(event *github.Event, i int) Line {
 		}
 	case "DiscussionEvent":
 		e := payload.(*github.DiscussionEvent)
-		line = NewLineByDiscussion(*event.Repo.Name, *e.Discussion)
+		discussion := getDiscussion(f.ctx, f.client, *event.Repo.Name, *e.Discussion.Number)
+		if discussion != nil {
+			line = NewLineByDiscussion(*event.Repo.Name, *discussion)
+		} else {
+			line = NewLineByDiscussion(*event.Repo.Name, *e.Discussion)
+		}
 	}
 
 	if f.debug {
@@ -147,6 +152,23 @@ func getPullRequest(ctx context.Context, client *github.Client, repoFullName str
 	owner, repo := getOwnerRepo(repoFullName)
 	pr, _, _ := client.PullRequests.Get(ctx, owner, repo, number)
 	return pr
+}
+
+// Re-fetches the Discussion via the raw client because go-github v80 has no
+// Discussions service wrapper. Functionally redundant today since the event
+// payload already carries fresh state; kept for parity with getIssue / getPullRequest.
+func getDiscussion(ctx context.Context, client *github.Client, repoFullName string, number int) *github.Discussion {
+	owner, repo := getOwnerRepo(repoFullName)
+	u := fmt.Sprintf("repos/%v/%v/discussions/%d", owner, repo, number)
+	req, err := client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil
+	}
+	discussion := new(github.Discussion)
+	if _, err := client.Do(ctx, req, discussion); err != nil {
+		return nil
+	}
+	return discussion
 }
 
 func getIssueStatus(issue github.Issue) string {

--- a/lib/format.go
+++ b/lib/format.go
@@ -56,6 +56,17 @@ func NewLineByPullRequest(repoName string, pr github.PullRequest) Line {
 	}
 }
 
+// NewLineByDiscussion is an initializer by Discussion
+func NewLineByDiscussion(repoName string, discussion github.Discussion) Line {
+	return Line{
+		title:    *discussion.Title,
+		repoName: repoName,
+		url:      *discussion.HTMLURL,
+		user:     *discussion.User.Login,
+		status:   getDiscussionStatus(discussion),
+	}
+}
+
 // Line returns Issue/PR info retrieving from GitHub
 func (f *Format) Line(event *github.Event, i int) Line {
 	payload := event.Payload()
@@ -114,6 +125,9 @@ func (f *Format) Line(event *github.Event, i int) Line {
 		} else {
 			line = NewLineByPullRequest(*event.Repo.Name, *e.PullRequest)
 		}
+	case "DiscussionEvent":
+		e := payload.(*github.DiscussionEvent)
+		line = NewLineByDiscussion(*event.Repo.Name, *e.Discussion)
 	}
 
 	if f.debug {
@@ -138,6 +152,14 @@ func getPullRequest(ctx context.Context, client *github.Client, repoFullName str
 func getIssueStatus(issue github.Issue) string {
 	result := ""
 	if *issue.State == "closed" {
+		result = "closed"
+	}
+	return result
+}
+
+func getDiscussionStatus(discussion github.Discussion) string {
+	result := ""
+	if *discussion.State == "closed" {
 		result = "closed"
 	}
 	return result

--- a/lib/format_test.go
+++ b/lib/format_test.go
@@ -22,9 +22,16 @@ func TestFormatAll(t *testing.T) {
 		HTMLURL: github.String("https://github.com/masutaka/github-nippou/pull/31"),
 		Merged:  github.Bool(true),
 	}
+	discussion := github.Discussion{
+		State:   github.String("closed"),
+		Title:   github.String("ロードマップ募集"),
+		User:    &github.User{Login: github.String("masutaka")},
+		HTMLURL: github.String("https://github.com/masutaka/github-nippou/discussions/2"),
+	}
 	lines := lib.Lines{
 		lib.NewLineByIssue("masutaka/github-nippou", issue),
 		lib.NewLineByPullRequest("masutaka/github-nippou", pr),
+		lib.NewLineByDiscussion("masutaka/github-nippou", discussion),
 	}
 	settings := lib.Settings{}
 	settings.Init("", "")
@@ -40,6 +47,7 @@ func TestFormatAll(t *testing.T) {
 	expected := `
 ### masutaka/github-nippou
 
+* [ロードマップ募集](https://github.com/masutaka/github-nippou/discussions/2) by @[masutaka](https://github.com/masutaka) **closed!**
 * [イベントを取得できないことがある](https://github.com/masutaka/github-nippou/issues/1) by @[masutaka](https://github.com/masutaka) **closed!**
 * [Bundle Update on 2015-10-04](https://github.com/masutaka/github-nippou/pull/31) by @[deppbot](https://github.com/deppbot) **merged!**
 `


### PR DESCRIPTION
- closes https://github.com/masutaka/github-nippou/issues/227

## Background

The Events API addition of `DiscussionEvent`, originally announced in the [GitHub Changelog (2024-11-08)](https://github.blog/changelog/2024-11-08-upcoming-changes-to-data-retention-for-events-api-atom-feed-timeline-and-dashboard-feed-features/), has finally rolled out as confirmed in [#227 (2026-04-03)](https://github.com/masutaka/github-nippou/issues/227#issuecomment-4182791086). This PR stops dropping `DiscussionEvent` in the filter and starts including it in the nippou output.

## Changes

Following the same pattern as [c1b55a2](https://github.com/masutaka/github-nippou/commit/c1b55a221045a4a942eed81a409480b89a08fc69) (PullRequestReviewEvent support):

- Add `DiscussionEvent` case to `filter` and `htmlURL` in `lib/events.go` (with the existing nil-check pattern)
- Add `NewLineByDiscussion` and `getDiscussionStatus` in `lib/format.go`. `getDiscussionStatus` only handles the `closed` state, mirroring `getIssueStatus`
- Add `getDiscussion` in `lib/format.go` to re-fetch the latest Discussion state, mirroring `getIssue` / `getPullRequest`. go-github v80 has no service wrapper for repository Discussions, so the raw client (`client.NewRequest` / `client.Do`) is used to call `GET /repos/{owner}/{repo}/discussions/{number}`. Falls back to the event payload on error
- Add a closed Discussion case to `TestFormatAll` in `lib/format_test.go`

Note: empirically the DiscussionEvent payload already carries the current Discussion state (e.g. an event with `action="created"` returns `state="closed"` after the discussion is closed), so this re-fetch is functionally redundant today. It is included for consistency with `getIssue` / `getPullRequest` and to avoid relying on that undocumented payload-freshness behavior.

## Out of scope

- **DiscussionCommentEvent**: I commented on a discussion and then checked `users/masutaka/events` directly. `IssueCommentEvent` is returned but `DiscussionCommentEvent` is not. go-github v80 defines the struct and the webhook mapping, but the Events API does not deliver it yet. To be revisited in a separate issue once the Events API supports it.
- **`answered` state (Q&A)**: Technically supportable today — the `Discussion` payload already contains `AnswerHTMLURL` / `AnswerChosenAt` / `AnswerChosenBy`, and `action="answered"` / `"unanswered"` exist in the DiscussionEvent action enum. Note that even an answered discussion has `state="open"` (verified with `repos/masutaka/sandbox/discussions/28`); answered is a separate axis from open/closed. Skipped here because it requires extending `dictionary.status` in `config/settings.yml` and changing the `getDiscussionStatus` shape away from the Issue/PR pattern. Separate issue.

