### PR TITLE
Fix deprecate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ $ github-nippou
 
 The following projects use github-nippou as a library:
 
-* https://github.com/ryoppippi/gh-nippou
-    * gh CLI extension for github-nippou
 * https://github.com/MH4GF/github-nippou-web
     * A web app version of github-nippou
 * https://github.com/NoritakaIkeda/GitJournal

--- a/README_ja.md
+++ b/README_ja.md
@@ -99,8 +99,6 @@ $ github-nippou
 
 以下のプロジェクトが github-nippou をライブラリとして利用しています:
 
-* https://github.com/ryoppippi/gh-nippou
-    * github-nippou の gh CLI 拡張
 * https://github.com/MH4GF/github-nippou-web
     * github-nippou の Web アプリ版
 * https://github.com/NoritakaIkeda/GitJournal

--- a/lib/events.go
+++ b/lib/events.go
@@ -59,11 +59,7 @@ func continueToRetrieve(response *github.Response, events []*github.Event, since
 
 	lastEvent := *events[len(events)-1]
 
-	if lastEvent.CreatedAt.Before(sinceTime.Add(-time.Nanosecond)) {
-		return false
-	}
-
-	return true
+	return !lastEvent.CreatedAt.Before(sinceTime.Add(-time.Nanosecond))
 }
 
 func selectEventsInRange(events []*github.Event, sinceTime, untilTime time.Time) []*github.Event {

--- a/lib/events.go
+++ b/lib/events.go
@@ -85,7 +85,12 @@ func (e *Events) filter(events []*github.Event) []*github.Event {
 	for _, event := range events {
 		if e.debug {
 			format := NewFormat(e.ctx, e.client, Settings{}, false)
-			fmt.Printf("[Debug] %s: %v\n", *event.Type, format.Line(event, 999))
+			line, err := format.Line(event, 999)
+			if err != nil {
+				fmt.Printf("[Debug] %s: parse error %v\n", *event.Type, err)
+			} else {
+				fmt.Printf("[Debug] %s: %v\n", *event.Type, line)
+			}
 		}
 
 		switch *event.Type {

--- a/lib/format.go
+++ b/lib/format.go
@@ -68,8 +68,11 @@ func NewLineByDiscussion(repoName string, discussion github.Discussion) Line {
 }
 
 // Line returns Issue/PR info retrieving from GitHub
-func (f *Format) Line(event *github.Event, i int) Line {
-	payload := event.Payload()
+func (f *Format) Line(event *github.Event, i int) (Line, error) {
+	payload, err := event.ParsePayload()
+	if err != nil {
+		return Line{}, err
+	}
 	var line Line
 
 	switch *event.Type {
@@ -139,7 +142,7 @@ func (f *Format) Line(event *github.Event, i int) Line {
 		fmt.Printf("[Debug] %2d %s: %v\n", i, *event.Type, line)
 	}
 
-	return line
+	return line, nil
 }
 
 func getIssue(ctx context.Context, client *github.Client, repoFullName string, number int) *github.Issue {

--- a/lib/format_test.go
+++ b/lib/format_test.go
@@ -10,23 +10,23 @@ import (
 
 func TestFormatAll(t *testing.T) {
 	issue := github.Issue{
-		State:   github.String("closed"),
-		Title:   github.String("イベントを取得できないことがある"),
-		User:    &github.User{Login: github.String("masutaka")},
-		HTMLURL: github.String("https://github.com/masutaka/github-nippou/issues/1"),
+		State:   github.Ptr("closed"),
+		Title:   github.Ptr("イベントを取得できないことがある"),
+		User:    &github.User{Login: github.Ptr("masutaka")},
+		HTMLURL: github.Ptr("https://github.com/masutaka/github-nippou/issues/1"),
 	}
 	pr := github.PullRequest{
-		State:   github.String("closed"),
-		Title:   github.String("Bundle Update on 2015-10-04"),
-		User:    &github.User{Login: github.String("deppbot")},
-		HTMLURL: github.String("https://github.com/masutaka/github-nippou/pull/31"),
-		Merged:  github.Bool(true),
+		State:   github.Ptr("closed"),
+		Title:   github.Ptr("Bundle Update on 2015-10-04"),
+		User:    &github.User{Login: github.Ptr("deppbot")},
+		HTMLURL: github.Ptr("https://github.com/masutaka/github-nippou/pull/31"),
+		Merged:  github.Ptr(true),
 	}
 	discussion := github.Discussion{
-		State:   github.String("closed"),
-		Title:   github.String("ロードマップ募集"),
-		User:    &github.User{Login: github.String("masutaka")},
-		HTMLURL: github.String("https://github.com/masutaka/github-nippou/discussions/2"),
+		State:   github.Ptr("closed"),
+		Title:   github.Ptr("ロードマップ募集"),
+		User:    &github.User{Login: github.Ptr("masutaka")},
+		HTMLURL: github.Ptr("https://github.com/masutaka/github-nippou/discussions/2"),
 	}
 	lines := lib.Lines{
 		lib.NewLineByIssue("masutaka/github-nippou", issue),

--- a/lib/list.go
+++ b/lib/list.go
@@ -86,21 +86,31 @@ func (l *List) Collect() (string, error) {
 	var lines Lines
 	var wg sync.WaitGroup
 	var mu sync.Mutex
+	var firstErr error
 
 	for i, event := range events {
 		wg.Add(1)
 		go func(event *github.Event, i int) {
 			defer wg.Done()
 			sem <- 1
-			line := format.Line(event, i)
+			line, lineErr := format.Line(event, i)
 			<-sem
 
 			mu.Lock()
 			defer mu.Unlock()
+			if lineErr != nil {
+				if firstErr == nil {
+					firstErr = lineErr
+				}
+				return
+			}
 			lines = append(lines, line)
 		}(event, i)
 	}
 	wg.Wait()
+	if firstErr != nil {
+		return "", firstErr
+	}
 
 	allLines, err := format.All(lines)
 	if err != nil {

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -144,12 +144,12 @@ func createGist(ctx context.Context, client *github.Client) (*github.Gist, *gith
 
 	gistFiles := make(map[github.GistFilename]github.GistFile, 1)
 	gistFiles["settings.yml"] = github.GistFile{
-		Content: github.String(content),
+		Content: github.Ptr(content),
 	}
 
 	gist := &github.Gist{
-		Description: github.String("github-nippou settings"),
-		Public:      github.Bool(true),
+		Description: github.Ptr("github-nippou settings"),
+		Public:      github.Ptr(true),
 		Files:       gistFiles,
 	}
 
@@ -173,7 +173,7 @@ func getDefaultSettingsYml() (string, error) {
 
 	defer file.Close()
 
-	yml, err := ioutil.ReadAll(file)
+	yml, err := io.ReadAll(file)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Background

`staticcheck ./lib/...` reported three warning kinds. This PR addresses `S1008` and `SA1019`. `ST1005` is left as-is (see Out of scope).

## Changes

Split into one commit per warning kind for review.

### S1008 — if-return simplification

- `lib/events.go`: collapse `if cond { return false }; return true` in `continueToRetrieve` into `return !cond`.

### SA1019 — deprecated APIs

- `event.Payload()` → `event.ParsePayload()` (`go-github`)
  - Background: `Payload()` panics on JSON unmarshal failure. `ParsePayload()` returns the error instead, so callers can handle it gracefully.
  - Code change: `Format.Line` now returns `(Line, error)`. In `List.Collect`, the parallel goroutine captures the first error under the existing mutex and propagates it. The debug branch in `(*Events).filter` surfaces the new error.
- `github.String` / `github.Bool` → `github.Ptr` (`go-github`)
  - Background: the per-type pointer helpers predate Go generics. After Go 1.18, go-github introduced the generic `func Ptr[T any](v T) *T` and deprecated the per-type variants in favor of a single helper.
  - Code change: replace all call sites in `lib/format_test.go` and `lib/settings.go`.
- `io/ioutil.ReadAll` → `io.ReadAll` (Go stdlib)
  - Background: as of Go 1.16, `io/ioutil`'s functions were moved to `io` and `os`, and the package itself was later marked `// Deprecated:`. `ioutil.ReadAll` is now `io.ReadAll`.
  - Code change: swap the import and the single call site in `lib/settings.go`.

## Library compatibility

Changing `(*Format).Line` to return `(Line, error)` is technically a breaking change to the public API and would normally call for a `/v5` module-path bump. Skipped because the known external consumers ([MH4GF/github-nippou-web](https://github.com/MH4GF/github-nippou-web), [NoritakaIkeda/GitJournal](https://github.com/NoritakaIkeda/GitJournal)) only use `lib.NewList` + `(*List).Collect`, and the `Line` struct's fields are unexported so calling `Format.Line` directly from the outside is impractical anyway.

## Out of scope

- `ST1005` at `lib/init.go:139` (`error strings should not end with punctuation or newlines`). The trailing newlines are intentional formatting for `fmt.Println(err)` at `cmd/init.go:16`. Fixing it would require either restructuring the message into a print-side guidance + short error or annotating with `//lint:ignore`. Skipped because the warning does not surface in my Emacs setup.