### PR TITLE
Synthesize PR html_url so dedup drops duplicate lines

### DIFF
--- a/lib/events.go
+++ b/lib/events.go
@@ -138,16 +138,16 @@ func htmlURL(event *github.Event) (string, error) {
 			result = *e.Issue.HTMLURL
 		}
 	case "PullRequestEvent":
-		if e := payload.(*github.PullRequestEvent); e.PullRequest != nil && e.PullRequest.HTMLURL != nil {
-			result = *e.PullRequest.HTMLURL
+		if e := payload.(*github.PullRequestEvent); e.PullRequest != nil && e.PullRequest.Number != nil {
+			result = pullRequestHTMLURL(event, *e.PullRequest.Number)
 		}
 	case "PullRequestReviewCommentEvent":
-		if e := payload.(*github.PullRequestReviewCommentEvent); e.PullRequest != nil && e.PullRequest.HTMLURL != nil {
-			result = *e.PullRequest.HTMLURL
+		if e := payload.(*github.PullRequestReviewCommentEvent); e.PullRequest != nil && e.PullRequest.Number != nil {
+			result = pullRequestHTMLURL(event, *e.PullRequest.Number)
 		}
 	case "PullRequestReviewEvent":
-		if e := payload.(*github.PullRequestReviewEvent); e.PullRequest != nil && e.PullRequest.HTMLURL != nil {
-			result = *e.PullRequest.HTMLURL
+		if e := payload.(*github.PullRequestReviewEvent); e.PullRequest != nil && e.PullRequest.Number != nil {
+			result = pullRequestHTMLURL(event, *e.PullRequest.Number)
 		}
 	case "DiscussionEvent":
 		if e := payload.(*github.DiscussionEvent); e.Discussion != nil && e.Discussion.HTMLURL != nil {
@@ -156,4 +156,16 @@ func htmlURL(event *github.Event) (string, error) {
 	}
 
 	return result, nil
+}
+
+// pullRequestHTMLURL constructs a PR's HTML URL from the event's repo and the
+// PR number. The /users/{user}/events API returns pull_request payloads
+// without an html_url, so we synthesize one to keep dedup keys consistent
+// with what IssueCommentEvent.Issue.HTMLURL returns for PR comments.
+func pullRequestHTMLURL(event *github.Event, number int) string {
+	if event.Repo == nil || event.Repo.Name == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("https://github.com/%s/pull/%d", *event.Repo.Name, number)
 }


### PR DESCRIPTION
## Background

Running `./github-nippou` produced duplicate lines for the same PR:

```
- [Replace deprecated 'app-id' input in create-github-app-token](https://github.com/masutaka/github-nippou/pull/329)
- [Replace deprecated 'app-id' input in create-github-app-token](https://github.com/masutaka/github-nippou/pull/329)
```

`(*Events).uniq` dedups by the URL pulled out of each event payload (`htmlURL` in `lib/events.go`). For PR-related events it read `payload.PullRequest.HTMLURL`, but the `/users/{user}/events` API returns the `pull_request` payload **without** `html_url` (only `number` is set). Verified directly:

```console
$ gh api 'users/masutaka/events?per_page=30' \
    --jq '.[] | select(.type=="PullRequestEvent") | {pr_url: .payload.pull_request.html_url, pr_number: .payload.pull_request.number}'
{"pr_number":329,"pr_url":null}
{"pr_number":329,"pr_url":null}
{"pr_number":327,"pr_url":null}
...
```

This caused two distinct symptoms:

- **Duplicate lines.** The first `PullRequestEvent` on PR #329 (dedup key `""`) and the corresponding `IssueCommentEvent` on the same PR (dedup key `/pull/329` from `issue.html_url`) had different keys, so both passed `uniq`. `Format.Line` then resolved both to the same `/pull/329` URL — producing two identical lines.
- **Silently dropped PRs.** Every `PullRequestEvent` / `PullRequestReviewEvent` / `PullRequestReviewCommentEvent` mapped to `""`, so only the first one survived `uniq`. Other PRs touched only by these event types in the same range were dropped from the output entirely. In my reproduction PRs #326 and #327 were missing.

## Changes

- Add `pullRequestHTMLURL(event, number)` which synthesizes `https://github.com/{repo}/pull/{number}` from `event.Repo.Name` + `payload.PullRequest.Number`. This matches the `/pull/N` form `IssueCommentEvent.Issue.HTMLURL` already returns for PR comments, so dedup keys align across the two event families.
- Switch the three PR-related cases in `htmlURL` to use it. The nil check moves from `e.PullRequest.HTMLURL != nil` to `e.PullRequest.Number != nil`, since `Number` is what the API actually populates.
- `IssuesEvent` / `IssueCommentEvent` / `DiscussionEvent` are unchanged — their payload `html_url` fields are populated correctly by the API.

## Verification

Before:

```
- [Support DiscussionEvent](.../issues/227) (Done)
- [Replace deprecated 'app-id' input in create-github-app-token](.../issues/328)
- [Replace deprecated 'app-id' input in create-github-app-token](.../pull/329)
- [Replace deprecated 'app-id' input in create-github-app-token](.../pull/329)  # duplicate
# PRs #326 and #327 missing
```

After:

```
- [Support DiscussionEvent](.../issues/227) (Done)
- [Replace deprecated 'app-id' input in create-github-app-token](.../issues/328)
- [Support DiscussionEvent](.../pull/326) (Done)
- [Fix deprecate warnings](.../pull/327) (Done)
- [Replace deprecated 'app-id' input in create-github-app-token](.../pull/329)
```
